### PR TITLE
[PythonDev] Make `test_replacement_scan.py` more standalone

### DIFF
--- a/tools/pythonpkg/tests/fast/test_replacement_scan.py
+++ b/tools/pythonpkg/tests/fast/test_replacement_scan.py
@@ -4,43 +4,48 @@ import pytest
 
 
 class TestReplacementScan(object):
-    def test_csv_replacement(self, duckdb_cursor):
+    def test_csv_replacement(self):
+        con = duckdb.connect()
         filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'integers.csv')
-        res = duckdb_cursor.execute("select count(*) from '%s'" % (filename))
+        res = con.execute("select count(*) from '%s'" % (filename))
         assert res.fetchone()[0] == 2
 
-    def test_parquet_replacement(self, duckdb_cursor):
+    def test_parquet_replacement(self):
+        con = duckdb.connect()
         filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', 'binary_string.parquet')
-        res = duckdb_cursor.execute("select count(*) from '%s'" % (filename))
+        res = con.execute("select count(*) from '%s'" % (filename))
         assert res.fetchone()[0] == 3
 
     def test_replacement_scan_relapi(self):
-        pyrel1 = duckdb.query('from (values (42), (84), (120)) t(i)')
+        con = duckdb.connect()
+        pyrel1 = con.query('from (values (42), (84), (120)) t(i)')
         assert isinstance(pyrel1, duckdb.DuckDBPyRelation)
         assert pyrel1.fetchall() == [(42,), (84,), (120,)]
 
-        pyrel2 = duckdb.query('from pyrel1 limit 2')
+        pyrel2 = con.query('from pyrel1 limit 2')
         assert isinstance(pyrel2, duckdb.DuckDBPyRelation)
         assert pyrel2.fetchall() == [(42,), (84,)]
 
-        pyrel3 = duckdb.query('select i + 100 from pyrel2')
+        pyrel3 = con.query('select i + 100 from pyrel2')
         assert type(pyrel3) == duckdb.DuckDBPyRelation
         assert pyrel3.fetchall() == [(142,), (184,)]
 
     def test_replacement_scan_alias(self):
-        pyrel1 = duckdb.query('from (values (1, 2)) t(i, j)')
-        pyrel2 = duckdb.query('from (values (1, 10)) t(i, k)')
-        pyrel3 = duckdb.query('from pyrel1 join pyrel2 using(i)')
+        con = duckdb.connect()
+        pyrel1 = con.query('from (values (1, 2)) t(i, j)')
+        pyrel2 = con.query('from (values (1, 10)) t(i, k)')
+        pyrel3 = con.query('from pyrel1 join pyrel2 using(i)')
         assert type(pyrel3) == duckdb.DuckDBPyRelation
         assert pyrel3.fetchall() == [(1, 2, 10)]
 
     def test_replacement_scan_pandas_alias(self):
-        df1 = duckdb.query('from (values (1, 2)) t(i, j)').df()
-        df2 = duckdb.query('from (values (1, 10)) t(i, k)').df()
-        df3 = duckdb.query('from df1 join df2 using(i)')
+        con = duckdb.connect()
+        df1 = con.query('from (values (1, 2)) t(i, j)').df()
+        df2 = con.query('from (values (1, 10)) t(i, k)').df()
+        df3 = con.query('from df1 join df2 using(i)')
         assert df3.fetchall() == [(1, 2, 10)]
 
-    def test_replacement_scan_fail(self, duckdb_cursor):
+    def test_replacement_scan_fail(self):
         random_object = "I love salmiak rondos"
         con = duckdb.connect()
         with pytest.raises(


### PR DESCRIPTION
Using `duckdb.sql` makes it prone to outside influence, so they now all use their own connection, hopefully fixes CI failing randomly in a non-reproducable manner