### PR TITLE
[Python] Create a Relation as part of ScanReplacement, so it can be used in `table` as well

### DIFF
--- a/src/include/duckdb/function/function.hpp
+++ b/src/include/duckdb/function/function.hpp
@@ -75,7 +75,7 @@ struct TableFunctionData : public FunctionData {
 
 struct PyTableFunctionData : public TableFunctionData {
 	//! External dependencies of this table function
-	unique_ptr<ExternalDependency> external_dependency;
+	shared_ptr<ExternalDependency> external_dependency;
 };
 
 struct FunctionParameters {

--- a/src/include/duckdb/main/relation/subquery_relation.hpp
+++ b/src/include/duckdb/main/relation/subquery_relation.hpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 class SubqueryRelation : public Relation {
 public:
-	SubqueryRelation(shared_ptr<Relation> child, string alias);
+	SubqueryRelation(shared_ptr<Relation> child, string alias, bool auto_init = true);
 
 	shared_ptr<Relation> child;
 	string alias;

--- a/src/include/duckdb/parser/tableref/table_function_ref.hpp
+++ b/src/include/duckdb/parser/tableref/table_function_ref.hpp
@@ -30,7 +30,7 @@ public:
 	unique_ptr<SelectStatement> subquery;
 
 	// External dependencies of this table function
-	unique_ptr<ExternalDependency> external_dependency;
+	shared_ptr<ExternalDependency> external_dependency;
 
 public:
 	string ToString() const override;

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -309,7 +309,7 @@ private:
 	BindTableFunctionInternal(TableFunction &table_function, const string &function_name, vector<Value> parameters,
 	                          named_parameter_map_t named_parameters, vector<LogicalType> input_table_types,
 	                          vector<string> input_table_names, const vector<string> &column_name_alias,
-	                          unique_ptr<ExternalDependency> external_dependency);
+	                          shared_ptr<ExternalDependency> external_dependency);
 
 	unique_ptr<LogicalOperator> CreatePlan(BoundBaseTableRef &ref);
 	unique_ptr<LogicalOperator> CreatePlan(BoundJoinRef &ref);

--- a/src/main/relation/subquery_relation.cpp
+++ b/src/main/relation/subquery_relation.cpp
@@ -4,12 +4,14 @@
 
 namespace duckdb {
 
-SubqueryRelation::SubqueryRelation(shared_ptr<Relation> child_p, string alias_p)
+SubqueryRelation::SubqueryRelation(shared_ptr<Relation> child_p, string alias_p, bool auto_init)
     : Relation(child_p->context, RelationType::SUBQUERY_RELATION), child(std::move(child_p)),
       alias(std::move(alias_p)) {
 	D_ASSERT(child.get() != this);
 	vector<ColumnDefinition> dummy_columns;
-	context.GetContext()->TryBindRelation(*this, dummy_columns);
+	if (auto_init) {
+		context.GetContext()->TryBindRelation(*this, dummy_columns);
+	}
 }
 
 unique_ptr<QueryNode> SubqueryRelation::GetQueryNode() {

--- a/src/main/relation/table_function_relation.cpp
+++ b/src/main/relation/table_function_relation.cpp
@@ -80,6 +80,7 @@ unique_ptr<TableRef> TableFunctionRelation::GetTableRef() {
 	auto table_function = make_uniq<TableFunctionRef>();
 	auto function = make_uniq<FunctionExpression>(name, std::move(children));
 	table_function->function = std::move(function);
+	table_function->external_dependency = this->extra_dependencies;
 	return std::move(table_function);
 }
 

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -132,7 +132,7 @@ unique_ptr<LogicalOperator>
 Binder::BindTableFunctionInternal(TableFunction &table_function, const string &function_name, vector<Value> parameters,
                                   named_parameter_map_t named_parameters, vector<LogicalType> input_table_types,
                                   vector<string> input_table_names, const vector<string> &column_name_alias,
-                                  unique_ptr<ExternalDependency> external_dependency) {
+                                  shared_ptr<ExternalDependency> external_dependency) {
 	auto bind_index = GenerateTableIndex();
 	// perform the binding
 	unique_ptr<FunctionData> bind_data;
@@ -284,10 +284,10 @@ unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
 		input_table_types = subquery->subquery->types;
 		input_table_names = subquery->subquery->names;
 	}
-	auto get = BindTableFunctionInternal(table_function, ref.alias.empty() ? fexpr.function_name : ref.alias,
-	                                     std::move(parameters), std::move(named_parameters),
-	                                     std::move(input_table_types), std::move(input_table_names),
-	                                     ref.column_name_alias, std::move(ref.external_dependency));
+	auto get =
+	    BindTableFunctionInternal(table_function, ref.alias.empty() ? fexpr.function_name : ref.alias,
+	                              std::move(parameters), std::move(named_parameters), std::move(input_table_types),
+	                              std::move(input_table_names), ref.column_name_alias, ref.external_dependency);
 	if (subquery) {
 		get->children.push_back(Binder::CreatePlan(*subquery));
 	}

--- a/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyrelation.hpp
@@ -261,6 +261,7 @@ public:
 	static bool IsRelation(const py::object &object);
 
 	Relation &GetRel();
+	shared_ptr<Relation> GetRelPtr();
 
 	bool ContainsColumnByName(const string &name) const;
 

--- a/tools/pythonpkg/src/pyconnection.cpp
+++ b/tools/pythonpkg/src/pyconnection.cpp
@@ -23,6 +23,7 @@
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
+#include "duckdb/parser/tableref.hpp"
 #include "duckdb_python/arrow/arrow_array_stream.hpp"
 #include "duckdb_python/map.hpp"
 #include "duckdb_python/pandas/pandas_scan.hpp"
@@ -1321,7 +1322,7 @@ static unique_ptr<TableFunctionRef> CreateArrowScan(py::object entry, ClientProp
 	table_function->function = make_uniq<FunctionExpression>("arrow_scan", std::move(children));
 	table_function->external_dependency =
 	    make_uniq<PythonDependencies>(make_uniq<RegisteredArrow>(std::move(stream_factory), entry));
-	return table_function;
+	return return std::move(table_function);
 }
 
 static unique_ptr<TableRef> TryReplacement(py::dict &dict, py::str &table_name, ClientProperties &client_properties,
@@ -1347,7 +1348,7 @@ static unique_ptr<TableRef> TryReplacement(py::dict &dict, py::str &table_name, 
 		table_function->function = make_uniq<FunctionExpression>("pandas_scan", std::move(children));
 		table_function->external_dependency =
 		    make_uniq<PythonDependencies>(make_uniq<RegisteredObject>(entry), make_uniq<RegisteredObject>(new_df));
-		return table_function;
+		return std::move(table_function);
 	}
 
 	if (DuckDBPyConnection::IsAcceptedArrowObject(entry)) {
@@ -1412,7 +1413,7 @@ static unique_ptr<TableRef> TryReplacement(py::dict &dict, py::str &table_name, 
 		table_function->function = make_uniq<FunctionExpression>("pandas_scan", std::move(children));
 		table_function->external_dependency =
 		    make_uniq<PythonDependencies>(make_uniq<RegisteredObject>(entry), make_uniq<RegisteredObject>(data));
-		return table_function;
+		return std::move(table_function);
 	}
 
 	std::string location = py::cast<py::str>(current_frame.attr("f_code").attr("co_filename"));

--- a/tools/pythonpkg/src/pyrelation.cpp
+++ b/tools/pythonpkg/src/pyrelation.cpp
@@ -227,10 +227,13 @@ py::list DuckDBPyRelation::Description() {
 }
 
 Relation &DuckDBPyRelation::GetRel() {
-	if (!rel) {
-		throw InternalException("DuckDBPyRelation - calling GetRel, but no rel was present");
-	}
+	AssertRelation();
 	return *rel;
+}
+
+shared_ptr<Relation> DuckDBPyRelation::GetRelPtr() {
+	AssertRelation();
+	return rel;
 }
 
 struct DescribeAggregateInfo {


### PR DESCRIPTION
This needs to be picked up again at some point.
So far the only work that has been done is clean up some code in TryReplacement