### PR TITLE
[Dev] Prevent same-thread deadlocks on ClientContextLock

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -274,16 +274,20 @@ class ClientContextLock {
 private:
 	// The identifier for an invalid thread
 	static const std::thread::id INVALID_THREAD;
+
 private:
-	explicit ClientContextLock(mutex &context_lock, atomic<std::thread::id> &marker) : client_guard(context_lock), marker(marker) {
+	explicit ClientContextLock(mutex &context_lock, atomic<std::thread::id> &marker)
+	    : client_guard(context_lock), marker(marker) {
 		// Set the current thread so lock attempts by the same thread don't result in a deadlock
 		marker = std::this_thread::get_id();
 	}
+
 public:
 	~ClientContextLock() {
 		// Unset the current thread before unlocking the client_guard
 		marker = INVALID_THREAD;
 	}
+
 public:
 	static unique_ptr<ClientContextLock> Lock(ClientContext &context) {
 		auto can_lock = context.context_lock.try_lock();

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -60,7 +60,8 @@ struct ActiveQueryContext {
 };
 
 ClientContext::ClientContext(shared_ptr<DatabaseInstance> database)
-    : db(std::move(database)), interrupted(false), client_data(make_uniq<ClientData>(*this)), transaction(*this), thread_id(std::thread::id()) {
+    : db(std::move(database)), interrupted(false), client_data(make_uniq<ClientData>(*this)), transaction(*this),
+      thread_id(std::thread::id()) {
 }
 
 ClientContext::~ClientContext() {


### PR DESCRIPTION
With this mechanism, we can prevent deadlocks caused by same-thread attempts to lock an already held lock.

Ideally I would like to just check if it's locked, instead of grabbing the lock if it's unlocked, because now I have to unlock and re-lock - or we would need to change the constructor of the LockedClientContextLock to accept an already held lock.

Neither of which are really what I want to do