### PR TITLE
Allowing aggregate operators to block

### DIFF
--- a/src/execution/operator/aggregate/physical_hash_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_hash_aggregate.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/common/optional_idx.hpp"
 
 namespace duckdb {
 
@@ -545,7 +546,7 @@ public:
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override;
 
 private:
-	void AggregateDistinctGrouping(const idx_t grouping_idx);
+	TaskExecutionResult AggregateDistinctGrouping(const idx_t grouping_idx);
 
 private:
 	Pipeline &pipeline;
@@ -553,6 +554,14 @@ private:
 
 	const PhysicalHashAggregate &op;
 	HashAggregateGlobalSinkState &gstate;
+
+	unique_ptr<LocalSinkState> local_sink_state;
+	idx_t grouping_idx = 0;
+	unique_ptr<LocalSourceState> radix_table_lstate;
+	bool blocked = false;
+	idx_t aggregation_idx = 0;
+	idx_t payload_idx = 0;
+	idx_t next_payload_idx = 0;
 };
 
 void HashAggregateDistinctFinalizeEvent::Schedule() {
@@ -600,14 +609,22 @@ void HashAggregateDistinctFinalizeEvent::FinishEvent() {
 }
 
 TaskExecutionResult HashAggregateDistinctFinalizeTask::ExecuteTask(TaskExecutionMode mode) {
-	for (idx_t grouping_idx = 0; grouping_idx < op.groupings.size(); grouping_idx++) {
-		AggregateDistinctGrouping(grouping_idx);
+	for (; grouping_idx < op.groupings.size(); grouping_idx++) {
+		auto res = AggregateDistinctGrouping(grouping_idx);
+		if (res == TaskExecutionResult::TASK_BLOCKED) {
+			return res;
+		}
+		D_ASSERT(res == TaskExecutionResult::TASK_FINISHED);
+		aggregation_idx = 0;
+		payload_idx = 0;
+		next_payload_idx = 0;
+		local_sink_state = nullptr;
 	}
 	event->FinishTask();
 	return TaskExecutionResult::TASK_FINISHED;
 }
 
-void HashAggregateDistinctFinalizeTask::AggregateDistinctGrouping(const idx_t grouping_idx) {
+TaskExecutionResult HashAggregateDistinctFinalizeTask::AggregateDistinctGrouping(const idx_t grouping_idx) {
 	D_ASSERT(op.distinct_collection_info);
 	auto &info = *op.distinct_collection_info;
 
@@ -624,9 +641,11 @@ void HashAggregateDistinctFinalizeTask::AggregateDistinctGrouping(const idx_t gr
 	ExecutionContext execution_context(executor.context, thread_context, &pipeline);
 
 	// Sink state to sink into global HTs
-	InterruptState interrupt_state;
+	InterruptState interrupt_state(shared_from_this());
 	auto &global_sink_state = *grouping_state.table_state;
-	auto local_sink_state = grouping_data.table_data.GetLocalSinkState(execution_context);
+	if (!local_sink_state) {
+		local_sink_state = grouping_data.table_data.GetLocalSinkState(execution_context);
+	}
 	OperatorSinkInput sink_input {global_sink_state, *local_sink_state, interrupt_state};
 
 	// Create a chunk that mimics the 'input' chunk in Sink, for storing the group vectors
@@ -635,24 +654,24 @@ void HashAggregateDistinctFinalizeTask::AggregateDistinctGrouping(const idx_t gr
 		group_chunk.Initialize(executor.context, op.input_group_types);
 	}
 
-	auto &groups = op.grouped_aggregate_data.groups;
-	const idx_t group_by_size = groups.size();
+	const idx_t group_by_size = op.grouped_aggregate_data.groups.size();
 
 	DataChunk aggregate_input_chunk;
 	if (!gstate.payload_types.empty()) {
 		aggregate_input_chunk.Initialize(executor.context, gstate.payload_types);
 	}
 
-	auto &finalize_event = event->Cast<HashAggregateDistinctFinalizeEvent>();
+	const auto &finalize_event = event->Cast<HashAggregateDistinctFinalizeEvent>();
 
-	idx_t payload_idx;
-	idx_t next_payload_idx = 0;
-	for (idx_t agg_idx = 0; agg_idx < op.grouped_aggregate_data.aggregates.size(); agg_idx++) {
+	auto &agg_idx = aggregation_idx;
+	for (; agg_idx < op.grouped_aggregate_data.aggregates.size(); agg_idx++) {
 		auto &aggregate = aggregates[agg_idx]->Cast<BoundAggregateExpression>();
 
-		// Forward the payload idx
-		payload_idx = next_payload_idx;
-		next_payload_idx = payload_idx + aggregate.children.size();
+		if (!blocked) {
+			// Forward the payload idx
+			payload_idx = next_payload_idx;
+			next_payload_idx = payload_idx + aggregate.children.size();
+		}
 
 		// If aggregate is not distinct, skip it
 		if (!distinct_data.IsDistinct(agg_idx)) {
@@ -664,8 +683,11 @@ void HashAggregateDistinctFinalizeTask::AggregateDistinctGrouping(const idx_t gr
 		auto &radix_table = distinct_data.radix_tables[table_idx];
 
 		auto &sink = *distinct_state.radix_states[table_idx];
-		auto local_source = radix_table->GetLocalSourceState(execution_context);
-		OperatorSourceInput source_input {*finalize_event.global_source_states[grouping_idx][agg_idx], *local_source,
+		if (!blocked) {
+			radix_table_lstate = radix_table->GetLocalSourceState(execution_context);
+		}
+		auto &local_source = *radix_table_lstate;
+		OperatorSourceInput source_input {*finalize_event.global_source_states[grouping_idx][agg_idx], local_source,
 		                                  interrupt_state};
 
 		// Create a duplicate of the output_chunk, because of multi-threading we cant alter the original
@@ -683,8 +705,8 @@ void HashAggregateDistinctFinalizeTask::AggregateDistinctGrouping(const idx_t gr
 				D_ASSERT(output_chunk.size() == 0);
 				break;
 			} else if (res == SourceResultType::BLOCKED) {
-				throw InternalException(
-				    "Unexpected interrupt from radix table GetData in HashAggregateDistinctFinalizeTask");
+				blocked = true;
+				return TaskExecutionResult::TASK_BLOCKED;
 			}
 
 			auto &grouped_aggregate_data = *distinct_data.grouped_aggregate_data[table_idx];
@@ -704,8 +726,10 @@ void HashAggregateDistinctFinalizeTask::AggregateDistinctGrouping(const idx_t gr
 			// Sink it into the main ht
 			grouping_data.table_data.Sink(execution_context, group_chunk, sink_input, aggregate_input_chunk, {agg_idx});
 		}
+		blocked = false;
 	}
 	grouping_data.table_data.Combine(execution_context, global_sink_state, *local_sink_state);
+	return TaskExecutionResult::TASK_FINISHED;
 }
 
 SinkFinalizeType PhysicalHashAggregate::FinalizeDistinct(Pipeline &pipeline, Event &event, ClientContext &context,
@@ -805,6 +829,7 @@ public:
 		}
 	}
 
+	optional_idx radix_idx;
 	vector<unique_ptr<LocalSourceState>> radix_states;
 };
 
@@ -819,32 +844,37 @@ SourceResultType PhysicalHashAggregate::GetData(ExecutionContext &context, DataC
 	auto &gstate = input.global_state.Cast<HashAggregateGlobalSourceState>();
 	auto &lstate = input.local_state.Cast<HashAggregateLocalSourceState>();
 	while (true) {
-		idx_t radix_idx = gstate.state_index;
+		if (!lstate.radix_idx.IsValid()) {
+			lstate.radix_idx = gstate.state_index.load();
+		}
+		const auto radix_idx = lstate.radix_idx.GetIndex();
 		if (radix_idx >= groupings.size()) {
 			break;
 		}
+
 		auto &grouping = groupings[radix_idx];
 		auto &radix_table = grouping.table_data;
 		auto &grouping_gstate = sink_gstate.grouping_states[radix_idx];
 
-		InterruptState interrupt_state;
 		OperatorSourceInput source_input {*gstate.radix_states[radix_idx], *lstate.radix_states[radix_idx],
-		                                  interrupt_state};
+		                                  input.interrupt_state};
 		auto res = radix_table.GetData(context, chunk, *grouping_gstate.table_state, source_input);
+		if (res == SourceResultType::BLOCKED) {
+			return res;
+		}
 		if (chunk.size() != 0) {
 			return SourceResultType::HAVE_MORE_OUTPUT;
-		} else if (res == SourceResultType::BLOCKED) {
-			throw InternalException("Unexpectedly Blocked from radix_table");
 		}
 
 		// move to the next table
 		lock_guard<mutex> l(gstate.lock);
-		radix_idx++;
-		if (radix_idx > gstate.state_index) {
+		lstate.radix_idx = lstate.radix_idx.GetIndex() + 1;
+		if (lstate.radix_idx.GetIndex() > gstate.state_index) {
 			// we have not yet worked on the table
 			// move the global index forwards
-			gstate.state_index = radix_idx;
+			gstate.state_index = lstate.radix_idx.GetIndex();
 		}
+		lstate.radix_idx = gstate.state_index.load();
 	}
 
 	return chunk.size() == 0 ? SourceResultType::FINISHED : SourceResultType::HAVE_MORE_OUTPUT;

--- a/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -402,13 +402,13 @@ public:
 	                                       const PhysicalUngroupedAggregate &op,
 	                                       UngroupedAggregateGlobalSinkState &state_p)
 	    : ExecutorTask(executor), event(std::move(event_p)), op(op), gstate(state_p),
-	      allocator(gstate.CreateAllocator()) {
+	      allocator(gstate.CreateAllocator()), aggregate_state(op.aggregates) {
 	}
 
 	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override;
 
 private:
-	void AggregateDistinct();
+	TaskExecutionResult AggregateDistinct();
 
 private:
 	shared_ptr<Event> event;
@@ -417,6 +417,12 @@ private:
 	UngroupedAggregateGlobalSinkState &gstate;
 
 	ArenaAllocator &allocator;
+
+	// Distinct aggregation state
+	AggregateState aggregate_state;
+	idx_t aggregation_idx = 0;
+	unique_ptr<LocalSourceState> radix_table_lstate;
+	bool blocked = false;
 };
 
 void UngroupedDistinctAggregateFinalizeEvent::Schedule() {
@@ -457,19 +463,21 @@ void UngroupedDistinctAggregateFinalizeEvent::Schedule() {
 }
 
 TaskExecutionResult UngroupedDistinctAggregateFinalizeTask::ExecuteTask(TaskExecutionMode mode) {
-	AggregateDistinct();
+	auto res = AggregateDistinct();
+	if (res == TaskExecutionResult::TASK_BLOCKED) {
+		return res;
+	}
 	event->FinishTask();
 	return TaskExecutionResult::TASK_FINISHED;
 }
 
-void UngroupedDistinctAggregateFinalizeTask::AggregateDistinct() {
+TaskExecutionResult UngroupedDistinctAggregateFinalizeTask::AggregateDistinct() {
 	D_ASSERT(gstate.distinct_state);
 	auto &distinct_state = *gstate.distinct_state;
 	auto &distinct_data = *op.distinct_data;
 
-	// Create thread-local copy of aggregate state
 	auto &aggregates = op.aggregates;
-	AggregateState state(aggregates);
+	auto &state = aggregate_state;
 
 	// Thread-local contexts
 	ThreadContext thread_context(executor.context);
@@ -478,14 +486,12 @@ void UngroupedDistinctAggregateFinalizeTask::AggregateDistinct() {
 	auto &finalize_event = event->Cast<UngroupedDistinctAggregateFinalizeEvent>();
 
 	// Now loop through the distinct aggregates, scanning the distinct HTs
-	idx_t payload_idx = 0;
-	idx_t next_payload_idx = 0;
-	for (idx_t agg_idx = 0; agg_idx < aggregates.size(); agg_idx++) {
-		auto &aggregate = aggregates[agg_idx]->Cast<BoundAggregateExpression>();
 
-		// Forward the payload idx
-		payload_idx = next_payload_idx;
-		next_payload_idx = payload_idx + aggregate.children.size();
+	// This needs to be preserved in case the radix_table.GetData blocks
+	auto &agg_idx = aggregation_idx;
+
+	for (; agg_idx < aggregates.size(); agg_idx++) {
+		auto &aggregate = aggregates[agg_idx]->Cast<BoundAggregateExpression>();
 
 		// If aggregate is not distinct, skip it
 		if (!distinct_data.IsDistinct(agg_idx)) {
@@ -494,11 +500,15 @@ void UngroupedDistinctAggregateFinalizeTask::AggregateDistinct() {
 
 		const auto table_idx = distinct_data.info.table_map.at(agg_idx);
 		auto &radix_table = *distinct_data.radix_tables[table_idx];
-		auto lstate = radix_table.GetLocalSourceState(execution_context);
+		if (!blocked) {
+			// Because we can block, we need to make sure we preserve this state
+			radix_table_lstate = radix_table.GetLocalSourceState(execution_context);
+		}
+		auto &lstate = *radix_table_lstate;
 
 		auto &sink = *distinct_state.radix_states[table_idx];
-		InterruptState interrupt_state;
-		OperatorSourceInput source_input {*finalize_event.global_source_states[agg_idx], *lstate, interrupt_state};
+		InterruptState interrupt_state(shared_from_this());
+		OperatorSourceInput source_input {*finalize_event.global_source_states[agg_idx], lstate, interrupt_state};
 
 		DataChunk output_chunk;
 		output_chunk.Initialize(executor.context, distinct_state.distinct_output_chunks[table_idx]->GetTypes());
@@ -516,8 +526,8 @@ void UngroupedDistinctAggregateFinalizeTask::AggregateDistinct() {
 				D_ASSERT(output_chunk.size() == 0);
 				break;
 			} else if (res == SourceResultType::BLOCKED) {
-				throw InternalException(
-				    "Unexpected interrupt from radix table GetData in UngroupedDistinctAggregateFinalizeTask");
+				blocked = true;
+				return TaskExecutionResult::TASK_BLOCKED;
 			}
 
 			// We dont need to resolve the filter, we already did this in Sink
@@ -536,12 +546,11 @@ void UngroupedDistinctAggregateFinalizeTask::AggregateDistinct() {
 			aggregate.function.simple_update(start_of_input, aggr_input_data, payload_cnt,
 			                                 state.aggregates[agg_idx].get(), payload_chunk.size());
 		}
+		blocked = false;
 	}
 
 	// After scanning the distinct HTs, we can combine the thread-local agg states with the thread-global
 	lock_guard<mutex> guard(finalize_event.lock);
-	payload_idx = 0;
-	next_payload_idx = 0;
 	for (idx_t agg_idx = 0; agg_idx < aggregates.size(); agg_idx++) {
 		if (!distinct_data.IsDistinct(agg_idx)) {
 			continue;
@@ -559,6 +568,7 @@ void UngroupedDistinctAggregateFinalizeTask::AggregateDistinct() {
 	if (++finalize_event.tasks_done == finalize_event.tasks_scheduled) {
 		gstate.finished = true;
 	}
+	return TaskExecutionResult::TASK_FINISHED;
 }
 
 SinkFinalizeType PhysicalUngroupedAggregate::FinalizeDistinct(Pipeline &pipeline, Event &event, ClientContext &context,

--- a/src/execution/operator/join/physical_hash_join.cpp
+++ b/src/execution/operator/join/physical_hash_join.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/storage/buffer_manager.hpp"
 #include "duckdb/storage/storage_manager.hpp"
+#include "duckdb/parallel/interrupt.hpp"
 #include "duckdb/storage/temporary_memory_manager.hpp"
 
 namespace duckdb {
@@ -583,7 +584,7 @@ public:
 	//! Initialize this source state using the info in the sink
 	void Initialize(HashJoinGlobalSinkState &sink);
 	//! Try to prepare the next stage
-	void TryPrepareNextStage(HashJoinGlobalSinkState &sink);
+	bool TryPrepareNextStage(HashJoinGlobalSinkState &sink);
 	//! Prepare the next build/probe/scan_ht stage for external hash join (must hold lock)
 	void PrepareBuild(HashJoinGlobalSinkState &sink);
 	void PrepareProbe(HashJoinGlobalSinkState &sink);
@@ -632,6 +633,8 @@ public:
 	idx_t full_outer_chunk_count;
 	idx_t full_outer_chunk_done;
 	idx_t full_outer_chunks_per_thread;
+
+	vector<InterruptState> blocked_tasks;
 };
 
 class HashJoinLocalSourceState : public LocalSourceState {
@@ -708,13 +711,14 @@ void HashJoinGlobalSourceState::Initialize(HashJoinGlobalSinkState &sink) {
 	TryPrepareNextStage(sink);
 }
 
-void HashJoinGlobalSourceState::TryPrepareNextStage(HashJoinGlobalSinkState &sink) {
+bool HashJoinGlobalSourceState::TryPrepareNextStage(HashJoinGlobalSinkState &sink) {
 	switch (global_stage.load()) {
 	case HashJoinSourceStage::BUILD:
 		if (build_chunk_done == build_chunk_count) {
 			sink.hash_table->GetDataCollection().VerifyEverythingPinned();
 			sink.hash_table->finalized = true;
 			PrepareProbe(sink);
+			return true;
 		}
 		break;
 	case HashJoinSourceStage::PROBE:
@@ -724,16 +728,19 @@ void HashJoinGlobalSourceState::TryPrepareNextStage(HashJoinGlobalSinkState &sin
 			} else {
 				PrepareBuild(sink);
 			}
+			return true;
 		}
 		break;
 	case HashJoinSourceStage::SCAN_HT:
 		if (full_outer_chunk_done == full_outer_chunk_count) {
 			PrepareBuild(sink);
+			return true;
 		}
 		break;
 	default:
 		break;
 	}
+	return false;
 }
 
 void HashJoinGlobalSourceState::PrepareBuild(HashJoinGlobalSinkState &sink) {
@@ -983,7 +990,15 @@ SourceResultType PhysicalHashJoin::GetData(ExecutionContext &context, DataChunk 
 			lstate.ExecuteTask(sink, gstate, chunk);
 		} else {
 			lock_guard<mutex> guard(gstate.lock);
-			gstate.TryPrepareNextStage(sink);
+			if (gstate.TryPrepareNextStage(sink) || gstate.global_stage == HashJoinSourceStage::DONE) {
+				for (auto &state : gstate.blocked_tasks) {
+					state.Callback();
+				}
+				gstate.blocked_tasks.clear();
+			} else {
+				gstate.blocked_tasks.push_back(input.interrupt_state);
+				return SourceResultType::BLOCKED;
+			}
 		}
 	}
 

--- a/src/execution/radix_partitioned_hashtable.cpp
+++ b/src/execution/radix_partitioned_hashtable.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/parallel/event.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/storage/temporary_memory_manager.hpp"
+#include "duckdb/parallel/interrupt.hpp"
 
 namespace duckdb {
 
@@ -175,6 +176,8 @@ public:
 	idx_t count_before_combining;
 	//! Maximum partition size if all unique
 	idx_t max_partition_size;
+
+	vector<InterruptState> blocked_tasks;
 };
 
 RadixHTGlobalSinkState::RadixHTGlobalSinkState(ClientContext &context_p, const RadixPartitionedHashTable &radix_ht_p)
@@ -526,7 +529,6 @@ void RadixPartitionedHashTable::Finalize(ClientContext &context, GlobalSinkState
 	auto max_threads =
 	    MinValue<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads(), gstate.partitions.size());
 	gstate.temporary_memory_state->SetRemainingSize(context, max_threads * gstate.max_partition_size);
-
 	gstate.finalized = true;
 }
 
@@ -572,8 +574,9 @@ public:
 	vector<column_t> column_ids;
 
 	//! For synchronizing scan tasks
-	atomic<idx_t> scan_idx;
-	atomic<idx_t> scan_done;
+	mutex lock;
+	idx_t scan_idx;
+	idx_t scan_done;
 };
 
 enum class RadixHTScanStatus : uint8_t { INIT, IN_PROGRESS, DONE };
@@ -635,18 +638,26 @@ bool RadixHTGlobalSourceState::AssignTask(RadixHTGlobalSinkState &sink, RadixHTL
 	if (finished) {
 		return false;
 	}
-	// We first try to assign a Scan task, then a Finalize task if that didn't work, without using any locks
 
-	// We need an atomic compare-and-swap to assign a Scan task, because we need to only increment
-	// the 'scan_idx' atomic if the 'finalize' of that partition is true, i.e., ready to be scanned
-	bool scan_assigned = true;
-	do {
-		lstate.task_idx = scan_idx.load();
-		if (lstate.task_idx >= n_partitions || !sink.partitions[lstate.task_idx]->finalized) {
-			scan_assigned = false;
-			break;
+	// We first try to assign a Scan task, then a Finalize task if that didn't work
+	bool scan_assigned = false;
+	{
+		lock_guard<mutex> gstate_guard(lock);
+		if (scan_idx < n_partitions && sink.partitions[scan_idx]->finalized) {
+			lstate.task_idx = scan_idx++;
+			scan_assigned = true;
+			if (scan_idx == n_partitions) {
+				// We will never be able to assign another task, unblock blocked tasks
+				lock_guard<mutex> sink_guard(sink.lock);
+				if (!sink.blocked_tasks.empty()) {
+					for (auto &state : sink.blocked_tasks) {
+						state.Callback();
+					}
+					sink.blocked_tasks.clear();
+				}
+			}
 		}
-	} while (!std::atomic_compare_exchange_weak(&scan_idx, &lstate.task_idx, lstate.task_idx + 1));
+	}
 
 	if (scan_assigned) {
 		// We successfully assigned a Scan task
@@ -669,7 +680,8 @@ bool RadixHTGlobalSourceState::AssignTask(RadixHTGlobalSinkState &sink, RadixHTL
 		return true;
 	}
 
-	// We didn't manage to assign a Finalize task
+	// We didn't manage to assign a Finalize task because there are none left
+	sink.temporary_memory_state->SetRemainingSize(context, 0);
 	return false;
 }
 
@@ -740,6 +752,17 @@ void RadixHTLocalSourceState::Finalize(RadixHTGlobalSinkState &sink, RadixHTGlob
 
 	// Mark partition as ready to scan
 	partition.finalized = true;
+
+	// Unblock blocked tasks so they can scan this partition
+	{
+		lock_guard<mutex> sink_guard(sink.lock);
+		if (!sink.blocked_tasks.empty()) {
+			for (auto &state : sink.blocked_tasks) {
+				state.Callback();
+			}
+			sink.blocked_tasks.clear();
+		}
+	}
 
 	// Make sure this thread's aggregate allocator does not get lost
 	lock_guard<mutex> guard(sink.lock);
@@ -834,7 +857,6 @@ SourceResultType RadixPartitionedHashTable::GetData(ExecutionContext &context, D
 	         sink.scan_pin_properties == TupleDataPinProperties::DESTROY_AFTER_DONE);
 
 	if (gstate.finished) {
-		sink.temporary_memory_state->SetRemainingSize(context.client, 0);
 		return SourceResultType::FINISHED;
 	}
 
@@ -875,6 +897,15 @@ SourceResultType RadixPartitionedHashTable::GetData(ExecutionContext &context, D
 	while (!gstate.finished && chunk.size() == 0) {
 		if (!lstate.TaskFinished() || gstate.AssignTask(sink, lstate)) {
 			lstate.ExecuteTask(sink, gstate, chunk);
+		} else {
+			lock_guard<mutex> gstate_guard(gstate.lock);
+			if (gstate.scan_idx < sink.partitions.size()) {
+				lock_guard<mutex> sink_guard(sink.lock);
+				sink.blocked_tasks.push_back(input.interrupt_state);
+				return SourceResultType::BLOCKED;
+			} else {
+				return SourceResultType::FINISHED;
+			}
 		}
 	}
 


### PR DESCRIPTION
For a future PR that makes use of InterruptState to halt execution of the plan these changes are necessary.
On top of that they should also help make better use of the CPU in some scenarios, because this removes spinlocking altoghether.

### RadixPartitionedHashTable::GetData:
Tasks that could not get work assigned to them will no longer spinlock, and will instead block.
These tasks rely on the tasks that *did* get assigned work to unblock them before they finish

### HashAggregateDistinctFinalizeTask:
Because it uses the RadixPartitionedHashtable, it now preserves state so it supports blocking of the RadixPartitionedHashtable::GetData call

### UngroupedDistinctAggregateFinalizeTask:
Because it uses the RadixPartitionedHashtable, it now preserves state so it supports blocking of the RadixPartitionedHashtable::GetData call

### HashAggregateLocalSourceState:
Now keeps an `optional_idx radix_idx` to remember what table it is scanning
This is necessary because `PhysicalHashAggregate::GetData` uses RadixPartitionedHashtable::GetData
So a table could be assigned, the task then blocks, the task then gets rescheduled and the global table index could have changed in the meantime.
We have to finish scanning the table assigned to us, so it's now preserved in the local state.

### PhysicalHashJoin::GetData:
Previously this operator would spinlock if no work was available for it, instead we now block in this case

The idea behind this change is that if no work is available, there are other tasks that aren't blocked, that are working
So these tasks are now responsible for unblocking the tasks that could not find work