### PR TITLE
[Python] Fix bug in conversion of nested Dictionary objects

### DIFF
--- a/tools/pythonpkg/src/native/python_conversion.cpp
+++ b/tools/pythonpkg/src/native/python_conversion.cpp
@@ -81,13 +81,19 @@ Value TransformDictionaryToStruct(const PyDictionary &dict, const LogicalType &t
 	return Value::STRUCT(std::move(struct_values));
 }
 
-Value TransformStructFormatDictionaryToMap(const PyDictionary &dict) {
+Value TransformStructFormatDictionaryToMap(const PyDictionary &dict, const LogicalType &target_type) {
 	if (dict.len == 0) {
 		return EmptyMapValue();
 	}
 
+	if (target_type.id() != LogicalTypeId::MAP) {
+		throw InvalidInputException("Please provide a valid target type for transform from Python to Value");
+	}
 	auto size = py::len(dict.keys);
 	D_ASSERT(size == py::len(dict.values));
+
+	auto key_target = MapType::KeyType(target_type);
+	auto value_target = MapType::ValueType(target_type);
 
 	LogicalType key_type = LogicalType::SQLNULL;
 	LogicalType value_type = LogicalType::SQLNULL;
@@ -95,8 +101,8 @@ Value TransformStructFormatDictionaryToMap(const PyDictionary &dict) {
 	vector<Value> elements;
 	for (idx_t i = 0; i < size; i++) {
 
-		Value new_key = TransformPythonValue(dict.keys.attr("__getitem__")(i));
-		Value new_value = TransformPythonValue(dict.values.attr("__getitem__")(i));
+		Value new_key = TransformPythonValue(dict.keys.attr("__getitem__")(i), key_target);
+		Value new_value = TransformPythonValue(dict.values.attr("__getitem__")(i), value_target);
 
 		key_type = LogicalType::ForceMaxLogicalType(key_type, new_key.type());
 		value_type = LogicalType::ForceMaxLogicalType(value_type, new_value.type());
@@ -116,7 +122,7 @@ Value TransformStructFormatDictionaryToMap(const PyDictionary &dict) {
 Value TransformDictionaryToMap(const PyDictionary &dict, const LogicalType &target_type = LogicalType::UNKNOWN) {
 	if (target_type.id() != LogicalTypeId::UNKNOWN && !DictionaryHasMapFormat(dict)) {
 		// dict == { 'k1': v1, 'k2': v2, ..., 'kn': vn }
-		return TransformStructFormatDictionaryToMap(dict);
+		return TransformStructFormatDictionaryToMap(dict, target_type);
 	}
 
 	auto keys = dict.values.attr("__getitem__")(0);


### PR DESCRIPTION
This PR fixes <insert PR>

We now properly propagate the "target type" to fix the situation where the produced Value and the type of the Vector differ.