### PR TITLE
[Python] Throw an error if a RecordBatchReader is read more than once

### DIFF
--- a/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
+++ b/tools/pythonpkg/src/arrow/arrow_array_stream.cpp
@@ -30,7 +30,7 @@ void VerifyArrowDatasetLoaded() {
 	}
 }
 
-PyArrowObjectType GetArrowType(const py::handle &obj) {
+PyArrowObjectType PythonTableArrowArrayStreamFactory::GetArrowType(const py::handle &obj) {
 	D_ASSERT(py::gil_check());
 	auto &import_cache = *DuckDBPyConnection::ImportCache();
 	// First Verify Lib Types

--- a/tools/pythonpkg/src/include/duckdb_python/arrow/arrow_array_stream.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/arrow/arrow_array_stream.hpp
@@ -54,8 +54,6 @@ enum class PyArrowObjectType { Invalid, Table, RecordBatchReader, Scanner, Datas
 
 void TransformDuckToArrowChunk(ArrowSchema &arrow_schema, ArrowArray &data, py::list &batches);
 
-PyArrowObjectType GetArrowType(const py::handle &obj);
-
 class PythonTableArrowArrayStreamFactory {
 public:
 	explicit PythonTableArrowArrayStreamFactory(PyObject *arrow_table, const ClientProperties &client_properties_p)
@@ -63,6 +61,8 @@ public:
 
 	//! Produces an Arrow Scanner, should be only called once when initializing Scan States
 	static unique_ptr<ArrowArrayStreamWrapper> Produce(uintptr_t factory, ArrowStreamParameters &parameters);
+
+	static PyArrowObjectType GetArrowType(const py::handle &obj);
 
 	//! Get the schema of the arrow object
 	static void GetSchemaInternal(py::handle arrow_object, ArrowSchemaWrapper &schema);

--- a/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -217,7 +217,7 @@ public:
 
 	static bool IsPandasDataframe(const py::object &object);
 	static bool IsPolarsDataframe(const py::object &object);
-	static bool IsAcceptedArrowObject(const py::object &object);
+	static PyArrowObjectType IsAcceptedArrowObject(const py::object &object);
 	static NumpyObjectType IsAcceptedNumpyObject(const py::object &object);
 
 	static unique_ptr<QueryResult> CompletePendingQuery(PendingQueryResult &pending_query);

--- a/tools/pythonpkg/src/include/duckdb_python/python_context_state.hpp
+++ b/tools/pythonpkg/src/include/duckdb_python/python_context_state.hpp
@@ -3,6 +3,7 @@
 #include "duckdb/main/client_context_state.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/parser/tableref.hpp"
+#include "duckdb_python/pybind11/pybind_wrapper.hpp"
 
 namespace duckdb {
 
@@ -24,6 +25,18 @@ public:
 	case_insensitive_map_t<unique_ptr<TableRef>> cache;
 };
 
+class RecordBatchReaderRegistry {
+public:
+	RecordBatchReaderRegistry();
+
+public:
+	void AddRecordBatchReader(PyObject *record_batch_reader);
+
+public:
+	//! Scanned record batch readers
+	unordered_set<PyObject *> consumed;
+};
+
 class PythonContextState : public ClientContextState {
 public:
 	PythonContextState();
@@ -35,6 +48,10 @@ public:
 public:
 	//! Cache the replacement scan lookups
 	ReplacementCache cache;
+	//! Used to keep track of which record batch readers have been consumed
+	// FIXME: this should probably be global, nothing is protecting multiple connections from using the same record
+	// batch reader
+	RecordBatchReaderRegistry registry;
 };
 
 } // namespace duckdb

--- a/tools/pythonpkg/src/python_context_state.cpp
+++ b/tools/pythonpkg/src/python_context_state.cpp
@@ -2,6 +2,18 @@
 
 namespace duckdb {
 
+RecordBatchReaderRegistry::RecordBatchReaderRegistry() {
+}
+
+void RecordBatchReaderRegistry::AddRecordBatchReader(PyObject *record_batch_reader) {
+	// FIXME: we should differentiate between replacement scanned and consumed
+	// a plan could be canceled, making it so the reader was never consumed
+	auto result = consumed.insert(record_batch_reader).second;
+	if (!result) {
+		throw InvalidInputException("Attempted to read from the same RecordBatchReader more than once!");
+	}
+}
+
 // Replacement Cache
 
 ReplacementCache::ReplacementCache() {

--- a/tools/pythonpkg/src/python_replacement_scan.cpp
+++ b/tools/pythonpkg/src/python_replacement_scan.cpp
@@ -14,6 +14,52 @@
 
 namespace duckdb {
 
+namespace {
+
+enum class ReplacementScanType {
+	RELATION,
+	PANDAS_DATAFRAME,
+	POLARS_DATAFRAME,
+	POLARS_LAZYFRAME,
+	PYARROW_TABLE,
+	PYARROW_RECORD_BATCH_READER,
+	PYARROW_DATASET,
+	PYARROW_SCANNER,
+	NUMPY_OBJECT,
+	UNKNOWN
+};
+
+class ReplacementScanResult {
+public:
+	ReplacementScanResult(ReplacementScanType type, unique_ptr<TableRef> result, PyObject *ptr)
+	    : type(type), result(std::move(result)), object(ptr) {
+		D_ASSERT(type != ReplacementScanType::UNKNOWN);
+	}
+	ReplacementScanResult() : type(ReplacementScanType::UNKNOWN), result(nullptr), object(nullptr) {
+	}
+	ReplacementScanResult(ReplacementScanResult &&other)
+	    : type(other.type), result(std::move(other.result)), object(other.object) {
+	}
+	ReplacementScanResult &operator=(ReplacementScanResult &&other) {
+		type = other.type;
+		result = std::move(other.result);
+		object = other.object;
+		return *this;
+	}
+
+public:
+	bool IsValid() const {
+		return result != nullptr;
+	}
+
+public:
+	ReplacementScanType type;
+	unique_ptr<TableRef> result;
+	PyObject *object;
+};
+
+} // namespace
+
 static void CreateArrowScan(py::object entry, TableFunctionRef &table_function,
                             vector<unique_ptr<ParsedExpression>> &children, ClientProperties &client_properties) {
 	string name = "arrow_" + StringUtil::GenerateRandomName();
@@ -30,17 +76,77 @@ static void CreateArrowScan(py::object entry, TableFunctionRef &table_function,
 	    make_uniq<PythonDependencies>(make_uniq<RegisteredArrow>(std::move(stream_factory), entry));
 }
 
-static unique_ptr<TableRef> TryReplacement(py::dict &dict, py::str &table_name, ClientProperties &client_properties,
-                                           py::object &current_frame) {
+static ReplacementScanType GetReplacementType(const py::object &entry) {
+	if (DuckDBPyConnection::IsPandasDataframe(entry)) {
+		return ReplacementScanType::PANDAS_DATAFRAME;
+	}
+	auto arrow_type = DuckDBPyConnection::IsAcceptedArrowObject(entry);
+	if (arrow_type != PyArrowObjectType::Invalid) {
+		switch (arrow_type) {
+		case PyArrowObjectType::Table:
+			return ReplacementScanType::PYARROW_TABLE;
+		case PyArrowObjectType::Scanner:
+			return ReplacementScanType::PYARROW_SCANNER;
+		case PyArrowObjectType::Dataset:
+			return ReplacementScanType::PYARROW_DATASET;
+		case PyArrowObjectType::RecordBatchReader:
+			return ReplacementScanType::PYARROW_RECORD_BATCH_READER;
+		default:
+			throw InternalException("Unrecognized PyArrowObjectType");
+		}
+	}
+	if (DuckDBPyRelation::IsRelation(entry)) {
+		return ReplacementScanType::RELATION;
+	}
+	if (PolarsDataFrame::IsDataFrame(entry)) {
+		return ReplacementScanType::POLARS_DATAFRAME;
+	}
+	if (PolarsDataFrame::IsLazyFrame(entry)) {
+		return ReplacementScanType::POLARS_LAZYFRAME;
+	}
+	auto numpytype = DuckDBPyConnection::IsAcceptedNumpyObject(entry);
+	if (numpytype != NumpyObjectType::INVALID) {
+		return ReplacementScanType::NUMPY_OBJECT;
+	}
+	return ReplacementScanType::UNKNOWN;
+}
+
+static ReplacementScanResult TryReplacement(py::dict &dict, py::str &table_name, ClientProperties &client_properties,
+                                            py::object &current_frame) {
 	if (!dict.contains(table_name)) {
 		// not present in the globals
-		return nullptr;
+		return ReplacementScanResult();
 	}
 	auto entry = dict[table_name];
+
+	auto replacement_type = GetReplacementType(entry);
+	if (replacement_type == ReplacementScanType::UNKNOWN) {
+		string location = py::cast<py::str>(current_frame.attr("f_code").attr("co_filename"));
+		location += ":";
+		location += py::cast<py::str>(current_frame.attr("f_lineno"));
+		string cpp_table_name = table_name;
+		auto py_object_type = string(py::str(entry.get_type().attr("__name__")));
+
+		throw InvalidInputException(
+		    "Python Object \"%s\" of type \"%s\" found on line \"%s\" not suitable for replacement scans.\nMake sure "
+		    "that \"%s\" is either a pandas.DataFrame, duckdb.DuckDBPyRelation, pyarrow Table, Dataset, "
+		    "RecordBatchReader, Scanner, or NumPy ndarrays with supported format",
+		    cpp_table_name, py_object_type, location, cpp_table_name);
+	}
+
 	auto table_function = make_uniq<TableFunctionRef>();
 	vector<unique_ptr<ParsedExpression>> children;
-	NumpyObjectType numpytype; // Identify the type of accepted numpy objects.
-	if (DuckDBPyConnection::IsPandasDataframe(entry)) {
+	switch (replacement_type) {
+	case ReplacementScanType::RELATION: {
+		auto pyrel = py::cast<DuckDBPyRelation *>(entry);
+		// create a subquery from the underlying relation object
+		auto select = make_uniq<SelectStatement>();
+		select->node = pyrel->GetRel().GetQueryNode();
+
+		auto subquery = make_uniq<SubqueryRef>(std::move(select));
+		return ReplacementScanResult(replacement_type, std::move(subquery), entry.ptr());
+	}
+	case ReplacementScanType::PANDAS_DATAFRAME: {
 		if (PandasDataFrame::IsPyArrowBacked(entry)) {
 			auto table = PandasDataFrame::ToArrowTable(entry);
 			CreateArrowScan(table, *table_function, children, client_properties);
@@ -52,28 +158,32 @@ static unique_ptr<TableRef> TryReplacement(py::dict &dict, py::str &table_name, 
 			table_function->external_dependency =
 			    make_uniq<PythonDependencies>(make_uniq<RegisteredObject>(entry), make_uniq<RegisteredObject>(new_df));
 		}
-
-	} else if (DuckDBPyConnection::IsAcceptedArrowObject(entry)) {
-		CreateArrowScan(entry, *table_function, children, client_properties);
-	} else if (DuckDBPyRelation::IsRelation(entry)) {
-		auto pyrel = py::cast<DuckDBPyRelation *>(entry);
-		// create a subquery from the underlying relation object
-		auto select = make_uniq<SelectStatement>();
-		select->node = pyrel->GetRel().GetQueryNode();
-
-		auto subquery = make_uniq<SubqueryRef>(std::move(select));
-		return std::move(subquery);
-	} else if (PolarsDataFrame::IsDataFrame(entry)) {
+		break;
+	}
+	case ReplacementScanType::POLARS_DATAFRAME: {
 		auto arrow_dataset = entry.attr("to_arrow")();
 		CreateArrowScan(arrow_dataset, *table_function, children, client_properties);
-	} else if (PolarsDataFrame::IsLazyFrame(entry)) {
+		break;
+	}
+	case ReplacementScanType::POLARS_LAZYFRAME: {
 		auto materialized = entry.attr("collect")();
 		auto arrow_dataset = materialized.attr("to_arrow")();
 		CreateArrowScan(arrow_dataset, *table_function, children, client_properties);
-	} else if ((numpytype = DuckDBPyConnection::IsAcceptedNumpyObject(entry)) != NumpyObjectType::INVALID) {
+		break;
+	}
+	case ReplacementScanType::PYARROW_DATASET:
+	case ReplacementScanType::PYARROW_RECORD_BATCH_READER:
+	case ReplacementScanType::PYARROW_SCANNER:
+	case ReplacementScanType::PYARROW_TABLE: {
+		CreateArrowScan(entry, *table_function, children, client_properties);
+		break;
+	}
+	case ReplacementScanType::NUMPY_OBJECT: {
 		string name = "np_" + StringUtil::GenerateRandomName();
 		py::dict data; // we will convert all the supported format to dict{"key": np.array(value)}.
 		size_t idx = 0;
+		auto numpytype = DuckDBPyConnection::IsAcceptedNumpyObject(entry);
+		D_ASSERT(numpytype != NumpyObjectType::INVALID);
 		switch (numpytype) {
 		case NumpyObjectType::NDARRAY1D:
 			data["column0"] = entry;
@@ -103,23 +213,16 @@ static unique_ptr<TableRef> TryReplacement(py::dict &dict, py::str &table_name, 
 		table_function->function = make_uniq<FunctionExpression>("pandas_scan", std::move(children));
 		table_function->external_dependency =
 		    make_uniq<PythonDependencies>(make_uniq<RegisteredObject>(entry), make_uniq<RegisteredObject>(data));
-	} else {
-		std::string location = py::cast<py::str>(current_frame.attr("f_code").attr("co_filename"));
-		location += ":";
-		location += py::cast<py::str>(current_frame.attr("f_lineno"));
-		std::string cpp_table_name = table_name;
-		auto py_object_type = string(py::str(entry.get_type().attr("__name__")));
-
-		throw InvalidInputException(
-		    "Python Object \"%s\" of type \"%s\" found on line \"%s\" not suitable for replacement scans.\nMake sure "
-		    "that \"%s\" is either a pandas.DataFrame, duckdb.DuckDBPyRelation, pyarrow Table, Dataset, "
-		    "RecordBatchReader, Scanner, or NumPy ndarrays with supported format",
-		    cpp_table_name, py_object_type, location, cpp_table_name);
+		break;
 	}
-	return std::move(table_function);
+	default: {
+		throw InternalException("Unrecognized ReplacementScanType!");
+	}
+	}
+	return ReplacementScanResult(replacement_type, std::move(table_function), entry.ptr());
 }
 
-static unique_ptr<TableRef> ReplaceInternal(ClientContext &context, const string &table_name) {
+static ReplacementScanResult ReplaceInternal(ClientContext &context, const string &table_name) {
 	py::gil_scoped_acquire acquire;
 	auto py_table_name = py::str(table_name);
 	// Here we do an exhaustive search on the frame lineage
@@ -130,7 +233,7 @@ static unique_ptr<TableRef> ReplaceInternal(ClientContext &context, const string
 		// search local dictionary
 		if (local_dict) {
 			auto result = TryReplacement(local_dict, py_table_name, client_properties, current_frame);
-			if (result) {
+			if (result.IsValid()) {
 				return result;
 			}
 		}
@@ -138,14 +241,14 @@ static unique_ptr<TableRef> ReplaceInternal(ClientContext &context, const string
 		auto global_dict = py::reinterpret_borrow<py::dict>(current_frame.attr("f_globals"));
 		if (global_dict) {
 			auto result = TryReplacement(global_dict, py_table_name, client_properties, current_frame);
-			if (result) {
+			if (result.IsValid()) {
 				return result;
 			}
 		}
 		current_frame = current_frame.attr("f_back");
 	}
 	// Not found :(
-	return nullptr;
+	return ReplacementScanResult();
 }
 
 static PythonContextState &GetContextState(ClientContext &context) {
@@ -158,18 +261,21 @@ unique_ptr<TableRef> PythonReplacementScan::Replace(ClientContext &context, cons
 	auto &state = GetContextState(context);
 	auto &cache = state.cache;
 	// Check to see if this lookup is cached
-	auto result = cache.Lookup(table_name);
-	if (result) {
-		return std::move(result);
+	auto cached = cache.Lookup(table_name);
+	if (cached) {
+		return cached;
 	}
 	// Do the actual replacement scan
-	result = ReplaceInternal(context, table_name);
-	if (!result) {
+	auto result = ReplaceInternal(context, table_name);
+	if (!result.IsValid()) {
 		return nullptr;
 	}
 	// Add it to the cache if we got a hit
-	cache.Add(table_name, result->Copy());
-	return std::move(result);
+	if (result.type == ReplacementScanType::PYARROW_RECORD_BATCH_READER) {
+		state.registry.AddRecordBatchReader(result.object);
+	}
+	cache.Add(table_name, result.result->Copy());
+	return std::move(result.result);
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Since PyArrow RecordBatchReader objects are destructive (because they are stateful), they don't behave the same as native DuckDB tables, or Pandas/Polars DataFrames.

When we detect that a RecordBatchReader is encountered twice in a replacement scan, we throw an error.

## Remaining Issues

This state is kept inside the PythonContextState, which is created for every separate connection, meaning that this error does not occur when two separate connections read from the same record batch reader.
We should instead make the RecordBatchReaderRegistry global on the module level, using locks to ensure multiple connections can make use of it at the same time.

We record the RecordBatchReader the moment it is encountered in the replacement scan, relations could theoretically be canceled, so they never run.
Subsequent relations that reference the RecordBatchReader then cause an error to be thrown.
We should differentiate between found and consumed RecordBatchReaders so this doesn't happen.