### PR TITLE
[Parquet] Implement automatic shredding for `VARIANT` columns in COPY TO parquet

### DIFF
--- a/extension/parquet/CMakeLists.txt
+++ b/extension/parquet/CMakeLists.txt
@@ -26,6 +26,7 @@ set(PARQUET_EXTENSION_FILES
     parquet_timestamp.cpp
     parquet_writer.cpp
     parquet_shredding.cpp
+    parquet_column_schema.cpp
     serialize_parquet.cpp
     zstd_file_system.cpp
     geo_parquet.cpp)

--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -270,7 +270,8 @@ unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &cont
 		shredding_type = shredding_types->GetChild(name);
 	}
 
-	if (type.id() == LogicalTypeId::STRUCT && type.GetAlias() == "PARQUET_VARIANT") {
+	// if (type.id() == LogicalTypeId::STRUCT && type.GetAlias() == "PARQUET_VARIANT") {
+	if (type.id() == LogicalTypeId::VARIANT) {
 		const bool is_shredded = shredding_type != nullptr;
 
 		//! Build the child types for the Parquet VARIANT

--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -359,7 +359,12 @@ ParquetColumnSchema ColumnWriter::FillParquetSchema(const LogicalType &type, con
 		}
 		return map_column;
 	}
-	return ParquetColumnSchema::FromLogicalType(name, type, max_define, max_repeat, 0, null_type);
+	auto res = ParquetColumnSchema::FromLogicalType(name, type, max_define, max_repeat, 0, null_type);
+	if (field_id && field_id->set) {
+		res.field_id = field_id->field_id;
+	}
+
+	return res;
 }
 
 unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &context, ParquetWriter &writer,

--- a/extension/parquet/column_writer.cpp
+++ b/extension/parquet/column_writer.cpp
@@ -288,7 +288,7 @@ ParquetColumnSchema ColumnWriter::FillParquetSchema(const LogicalType &type, con
 			}
 		}
 
-		ParquetColumnSchema variant_column(name, type, max_define, max_repeat, 0, null_type);
+		auto variant_column = ParquetColumnSchema::FromLogicalType(name, type, max_define, max_repeat, 0, null_type);
 		variant_column.children.reserve(child_types.size());
 		for (auto &child_type : child_types) {
 			auto &child_name = child_type.first;
@@ -314,7 +314,7 @@ ParquetColumnSchema ColumnWriter::FillParquetSchema(const LogicalType &type, con
 	}
 
 	if (type.id() == LogicalTypeId::STRUCT || type.id() == LogicalTypeId::UNION) {
-		ParquetColumnSchema struct_column(name, type, max_define, max_repeat, 0, null_type);
+		auto struct_column = ParquetColumnSchema::FromLogicalType(name, type, max_define, max_repeat, 0, null_type);
 		if (field_id && field_id->set) {
 			struct_column.field_id = field_id->field_id;
 		}
@@ -333,7 +333,7 @@ ParquetColumnSchema ColumnWriter::FillParquetSchema(const LogicalType &type, con
 		auto is_list = type.id() == LogicalTypeId::LIST;
 		auto &child_type = is_list ? ListType::GetChildType(type) : ArrayType::GetChildType(type);
 
-		ParquetColumnSchema list_column(name, type, max_define, max_repeat, 0, null_type);
+		auto list_column = ParquetColumnSchema::FromLogicalType(name, type, max_define, max_repeat, 0, null_type);
 		list_column.children.push_back(FillParquetSchema(child_type, "element", child_field_ids, shredding_type,
 		                                                 max_repeat + 1, max_define + 2, true));
 		return list_column;
@@ -345,7 +345,7 @@ ParquetColumnSchema ColumnWriter::FillParquetSchema(const LogicalType &type, con
 		key_value.emplace_back("key", MapType::KeyType(type));
 		key_value.emplace_back("value", MapType::ValueType(type));
 
-		ParquetColumnSchema map_column(name, type, max_define, max_repeat, 0, null_type);
+		auto map_column = ParquetColumnSchema::FromLogicalType(name, type, max_define, max_repeat, 0, null_type);
 		map_column.children.reserve(2);
 		for (idx_t i = 0; i < 2; i++) {
 			// key needs to be marked as REQUIRED
@@ -359,7 +359,7 @@ ParquetColumnSchema ColumnWriter::FillParquetSchema(const LogicalType &type, con
 		}
 		return map_column;
 	}
-	return ParquetColumnSchema(name, type, max_define, max_repeat, 0, null_type);
+	return ParquetColumnSchema::FromLogicalType(name, type, max_define, max_repeat, 0, null_type);
 }
 
 unique_ptr<ColumnWriter> ColumnWriter::CreateWriterRecursive(ClientContext &context, ParquetWriter &writer,

--- a/extension/parquet/include/column_writer.hpp
+++ b/extension/parquet/include/column_writer.hpp
@@ -11,6 +11,7 @@
 #include "duckdb.hpp"
 #include "parquet_types.h"
 #include "parquet_column_schema.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 
 namespace duckdb {
 class MemoryStream;
@@ -110,6 +111,22 @@ public:
 	}
 	idx_t MaxRepeat() const {
 		return column_schema.max_repeat;
+	}
+	virtual bool HasTransform() {
+		for (auto &child_writer : child_writers) {
+			if (child_writer->HasTransform()) {
+				throw NotImplementedException("ColumnWriter of type '%s' requires a transform, but is not a root "
+				                              "column, this isn't supported currently",
+				                              child_writer->Type());
+			}
+		}
+		return false;
+	}
+	virtual LogicalType TransformedType() {
+		throw NotImplementedException("Writer does not have a transformed type");
+	}
+	virtual unique_ptr<Expression> TransformExpression(unique_ptr<BoundReferenceExpression> expr) {
+		throw NotImplementedException("Writer does not have a transform expression");
 	}
 
 	virtual unique_ptr<ParquetAnalyzeSchemaState> AnalyzeSchemaInit() {

--- a/extension/parquet/include/column_writer.hpp
+++ b/extension/parquet/include/column_writer.hpp
@@ -68,7 +68,7 @@ protected:
 	static constexpr uint16_t PARQUET_DEFINE_VALID = UINT16_C(65535);
 
 public:
-	ColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path);
+	ColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema, vector<string> schema_path);
 	virtual ~ColumnWriter();
 
 public:
@@ -92,16 +92,22 @@ public:
 		return column_schema.max_repeat;
 	}
 
+	virtual bool HasAnalyzeSchema() {
+		return false;
+	}
+
+	virtual void AnalyzeSchema() {
+		return;
+	}
+
 	virtual void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) = 0;
 
-	static ParquetColumnSchema FillParquetSchema(const LogicalType &type, const string &name,
-	                                             optional_ptr<const ChildFieldIDs> field_ids,
-	                                             optional_ptr<const ShreddingType> shredding_types,
-	                                             idx_t max_repeat = 0, idx_t max_define = 1,
-	                                             bool can_have_nulls = true);
 	//! Create the column writer for a specific type recursively
-	static unique_ptr<ColumnWriter> CreateWriterRecursive(ClientContext &context, ParquetWriter &writer,
-	                                                      ParquetColumnSchema &schema, vector<string> path_in_schema);
+	static unique_ptr<ColumnWriter>
+	CreateWriterRecursive(ClientContext &context, ParquetWriter &writer, vector<string> path_in_schema,
+	                      const LogicalType &type, const string &name, optional_ptr<const ChildFieldIDs> field_ids,
+	                      optional_ptr<const ShreddingType> shredding_types, idx_t max_repeat = 0, idx_t max_define = 1,
+	                      bool can_have_nulls = true);
 
 	virtual unique_ptr<ColumnWriterState> InitializeWriteState(duckdb_parquet::RowGroup &row_group) = 0;
 
@@ -136,7 +142,7 @@ protected:
 
 public:
 	ParquetWriter &writer;
-	ParquetColumnSchema &column_schema;
+	ParquetColumnSchema column_schema;
 	vector<string> schema_path;
 	bool can_have_nulls;
 

--- a/extension/parquet/include/column_writer.hpp
+++ b/extension/parquet/include/column_writer.hpp
@@ -68,8 +68,7 @@ protected:
 	static constexpr uint16_t PARQUET_DEFINE_VALID = UINT16_C(65535);
 
 public:
-	ColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema, vector<string> schema_path,
-	             bool can_have_nulls);
+	ColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path);
 	virtual ~ColumnWriter();
 
 public:
@@ -79,8 +78,12 @@ public:
 	const ParquetColumnSchema &Schema() const {
 		return column_schema;
 	}
+	ParquetColumnSchema &Schema() {
+		return column_schema;
+	}
 	inline idx_t SchemaIndex() const {
-		return column_schema.schema_index;
+		D_ASSERT(column_schema.schema_index.IsValid());
+		return column_schema.schema_index.GetIndex();
 	}
 	inline idx_t MaxDefine() const {
 		return column_schema.max_define;
@@ -89,15 +92,16 @@ public:
 		return column_schema.max_repeat;
 	}
 
-	static ParquetColumnSchema
-	FillParquetSchema(vector<duckdb_parquet::SchemaElement> &schemas, const LogicalType &type, const string &name,
-	                  optional_ptr<const ChildFieldIDs> field_ids, optional_ptr<const ShreddingType> shredding_types,
-	                  idx_t max_repeat = 0, idx_t max_define = 1, bool can_have_nulls = true);
+	virtual void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) = 0;
+
+	static ParquetColumnSchema FillParquetSchema(const LogicalType &type, const string &name,
+	                                             optional_ptr<const ChildFieldIDs> field_ids,
+	                                             optional_ptr<const ShreddingType> shredding_types,
+	                                             idx_t max_repeat = 0, idx_t max_define = 1,
+	                                             bool can_have_nulls = true);
 	//! Create the column writer for a specific type recursively
 	static unique_ptr<ColumnWriter> CreateWriterRecursive(ClientContext &context, ParquetWriter &writer,
-	                                                      const vector<duckdb_parquet::SchemaElement> &parquet_schemas,
-	                                                      const ParquetColumnSchema &schema,
-	                                                      vector<string> path_in_schema);
+	                                                      ParquetColumnSchema &schema, vector<string> path_in_schema);
 
 	virtual unique_ptr<ColumnWriterState> InitializeWriteState(duckdb_parquet::RowGroup &row_group) = 0;
 
@@ -132,7 +136,7 @@ protected:
 
 public:
 	ParquetWriter &writer;
-	const ParquetColumnSchema &column_schema;
+	ParquetColumnSchema &column_schema;
 	vector<string> schema_path;
 	bool can_have_nulls;
 

--- a/extension/parquet/include/column_writer.hpp
+++ b/extension/parquet/include/column_writer.hpp
@@ -63,6 +63,26 @@ public:
 	}
 };
 
+struct ParquetAnalyzeSchemaState {
+public:
+	ParquetAnalyzeSchemaState() {
+	}
+	virtual ~ParquetAnalyzeSchemaState() {
+	}
+
+public:
+	template <class TARGET>
+	TARGET &Cast() {
+		DynamicCastCheck<TARGET>(this);
+		return reinterpret_cast<TARGET &>(*this);
+	}
+	template <class TARGET>
+	const TARGET &Cast() const {
+		D_ASSERT(dynamic_cast<const TARGET *>(this));
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+};
+
 class ColumnWriter {
 protected:
 	static constexpr uint16_t PARQUET_DEFINE_VALID = UINT16_C(65535);
@@ -92,12 +112,16 @@ public:
 		return column_schema.max_repeat;
 	}
 
-	virtual bool HasAnalyzeSchema() {
-		return false;
+	virtual unique_ptr<ParquetAnalyzeSchemaState> AnalyzeSchemaInit() {
+		return nullptr;
 	}
 
-	virtual void AnalyzeSchema() {
-		return;
+	virtual void AnalyzeSchema(ParquetAnalyzeSchemaState &state, Vector &input, idx_t count) {
+		throw NotImplementedException("Writer doesn't require an AnalyzeSchema pass");
+	}
+
+	virtual void AnalyzeSchemaFinalize(const ParquetAnalyzeSchemaState &state) {
+		throw NotImplementedException("Writer doesn't require an AnalyzeSchemaFinalize pass");
 	}
 
 	virtual void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) = 0;

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -70,14 +70,14 @@ public:
 	void SetSchemaIndex(idx_t schema_idx);
 
 public:
-	ParquetColumnSchemaType schema_type;
 	string name;
-	LogicalType type;
 	idx_t max_define;
 	idx_t max_repeat;
-	//! Populated by FinalizeSchema
+	//! Populated by FinalizeSchema if used in the parquet_writer path
 	optional_idx schema_index;
 	idx_t column_index;
+	ParquetColumnSchemaType schema_type;
+	LogicalType type;
 	optional_idx parent_schema_index;
 	uint32_t type_length = 0;
 	uint32_t type_scale = 0;
@@ -86,7 +86,7 @@ public:
 	vector<ParquetColumnSchema> children;
 	optional_idx field_id;
 	//! Whether a column is nullable or not
-	duckdb_parquet::FieldRepetitionType::type repetition_type;
+	duckdb_parquet::FieldRepetitionType::type repetition_type = duckdb_parquet::FieldRepetitionType::OPTIONAL;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/parquet_column_schema.hpp
+++ b/extension/parquet/include/parquet_column_schema.hpp
@@ -16,6 +16,7 @@ using namespace duckdb_parquet; // NOLINT
 
 using duckdb_parquet::ConvertedType;
 using duckdb_parquet::FieldRepetitionType;
+using duckdb_parquet::SchemaElement;
 
 using duckdb_parquet::FileMetaData;
 struct ParquetOptions;
@@ -37,13 +38,29 @@ enum class ParquetExtraTypeInfo {
 struct ParquetColumnSchema {
 public:
 	ParquetColumnSchema() = default;
-	ParquetColumnSchema(idx_t max_define, idx_t max_repeat, idx_t schema_index, idx_t file_index,
-	                    ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
-	ParquetColumnSchema(
-	    string name, LogicalType type, idx_t max_define, idx_t max_repeat, idx_t column_index,
-	    duckdb_parquet::FieldRepetitionType::type repetition_type = duckdb_parquet::FieldRepetitionType::type::OPTIONAL,
-	    ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
-	ParquetColumnSchema(ParquetColumnSchema parent, LogicalType result_type, ParquetColumnSchemaType schema_type);
+	ParquetColumnSchema(ParquetColumnSchema &&other) = default;
+	ParquetColumnSchema(const ParquetColumnSchema &other) = default;
+	ParquetColumnSchema &operator=(ParquetColumnSchema &&other) = default;
+
+public:
+	//! Writer constructors
+	static ParquetColumnSchema FromLogicalType(const string &name, const LogicalType &type, idx_t max_define,
+	                                           idx_t max_repeat, idx_t column_index,
+	                                           duckdb_parquet::FieldRepetitionType::type repetition_type,
+	                                           ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
+
+public:
+	//! Reader constructors
+	static ParquetColumnSchema FromSchemaElement(const SchemaElement &element, idx_t max_define, idx_t max_repeat,
+	                                             idx_t schema_index, idx_t column_index, ParquetColumnSchemaType type,
+	                                             const ParquetOptions &options);
+	static ParquetColumnSchema FromParentSchema(ParquetColumnSchema parent, LogicalType result_type,
+	                                            ParquetColumnSchemaType schema_type);
+	static ParquetColumnSchema FromChildSchemas(const string &name, const LogicalType &type, idx_t max_define,
+	                                            idx_t max_repeat, idx_t schema_index, idx_t column_index,
+	                                            vector<ParquetColumnSchema> &&children,
+	                                            ParquetColumnSchemaType schema_type = ParquetColumnSchemaType::COLUMN);
+	static ParquetColumnSchema FileRowNumber();
 
 public:
 	unique_ptr<BaseStatistics> Stats(const FileMetaData &file_meta_data, const ParquetOptions &parquet_options,

--- a/extension/parquet/include/parquet_reader.hpp
+++ b/extension/parquet/include/parquet_reader.hpp
@@ -195,6 +195,8 @@ public:
 	static unique_ptr<BaseStatistics> ReadStatistics(const ParquetUnionData &union_data, const string &name);
 
 	LogicalType DeriveLogicalType(const SchemaElement &s_ele, ParquetColumnSchema &schema) const;
+	static LogicalType DeriveLogicalType(const SchemaElement &s_ele, const ParquetOptions &options,
+	                                     ParquetColumnSchema &schema);
 
 	void AddVirtualColumn(column_t virtual_column_id) override;
 

--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -140,6 +140,7 @@ public:
 	const string &GetFileName() const {
 		return file_name;
 	}
+	void AnalyzeSchema(ColumnDataCollection &buffer, vector<unique_ptr<ColumnWriter>> &column_writers);
 
 	uint32_t Write(const duckdb_apache::thrift::TBase &object);
 	uint32_t WriteData(const const_data_ptr_t buffer, const uint32_t buffer_size);
@@ -154,6 +155,7 @@ public:
 	void FlushColumnStats(idx_t col_idx, duckdb_parquet::ColumnChunk &chunk,
 	                      optional_ptr<ColumnWriterStatistics> writer_stats);
 	void InitializePreprocessing();
+	void InitializeSchemaElements();
 
 private:
 	void GatherWrittenStatistics();

--- a/extension/parquet/include/parquet_writer.hpp
+++ b/extension/parquet/include/parquet_writer.hpp
@@ -155,7 +155,6 @@ private:
 	bool debug_use_openssl;
 	shared_ptr<EncryptionUtil> encryption_util;
 	ParquetVersion parquet_version;
-	vector<ParquetColumnSchema> column_schemas;
 
 	unique_ptr<BufferedFileWriter> writer;
 	//! Atomics to reduce contention when rotating writes to multiple Parquet files

--- a/extension/parquet/include/writer/array_column_writer.hpp
+++ b/extension/parquet/include/writer/array_column_writer.hpp
@@ -14,9 +14,9 @@ namespace duckdb {
 
 class ArrayColumnWriter : public ListColumnWriter {
 public:
-	ArrayColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p,
+	ArrayColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema, vector<string> schema_path_p,
 	                  unique_ptr<ColumnWriter> child_writer_p)
-	    : ListColumnWriter(writer, column_schema, std::move(schema_path_p), std::move(child_writer_p)) {
+	    : ListColumnWriter(writer, std::move(column_schema), std::move(schema_path_p), std::move(child_writer_p)) {
 	}
 	~ArrayColumnWriter() override = default;
 

--- a/extension/parquet/include/writer/array_column_writer.hpp
+++ b/extension/parquet/include/writer/array_column_writer.hpp
@@ -14,9 +14,9 @@ namespace duckdb {
 
 class ArrayColumnWriter : public ListColumnWriter {
 public:
-	ArrayColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema, vector<string> schema_path_p,
-	                  unique_ptr<ColumnWriter> child_writer_p, bool can_have_nulls)
-	    : ListColumnWriter(writer, column_schema, std::move(schema_path_p), std::move(child_writer_p), can_have_nulls) {
+	ArrayColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p,
+	                  unique_ptr<ColumnWriter> child_writer_p)
+	    : ListColumnWriter(writer, column_schema, std::move(schema_path_p), std::move(child_writer_p)) {
 	}
 	~ArrayColumnWriter() override = default;
 

--- a/extension/parquet/include/writer/boolean_column_writer.hpp
+++ b/extension/parquet/include/writer/boolean_column_writer.hpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 class BooleanColumnWriter : public PrimitiveColumnWriter {
 public:
-	BooleanColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p);
+	BooleanColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema, vector<string> schema_path_p);
 	~BooleanColumnWriter() override = default;
 
 public:

--- a/extension/parquet/include/writer/boolean_column_writer.hpp
+++ b/extension/parquet/include/writer/boolean_column_writer.hpp
@@ -14,8 +14,7 @@ namespace duckdb {
 
 class BooleanColumnWriter : public PrimitiveColumnWriter {
 public:
-	BooleanColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema, vector<string> schema_path_p,
-	                    bool can_have_nulls);
+	BooleanColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p);
 	~BooleanColumnWriter() override = default;
 
 public:

--- a/extension/parquet/include/writer/decimal_column_writer.hpp
+++ b/extension/parquet/include/writer/decimal_column_writer.hpp
@@ -14,7 +14,7 @@ namespace duckdb {
 
 class FixedDecimalColumnWriter : public PrimitiveColumnWriter {
 public:
-	FixedDecimalColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p);
+	FixedDecimalColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema, vector<string> schema_path_p);
 	~FixedDecimalColumnWriter() override = default;
 
 public:

--- a/extension/parquet/include/writer/decimal_column_writer.hpp
+++ b/extension/parquet/include/writer/decimal_column_writer.hpp
@@ -14,8 +14,7 @@ namespace duckdb {
 
 class FixedDecimalColumnWriter : public PrimitiveColumnWriter {
 public:
-	FixedDecimalColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema,
-	                         vector<string> schema_path_p, bool can_have_nulls);
+	FixedDecimalColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p);
 	~FixedDecimalColumnWriter() override = default;
 
 public:

--- a/extension/parquet/include/writer/enum_column_writer.hpp
+++ b/extension/parquet/include/writer/enum_column_writer.hpp
@@ -15,8 +15,7 @@ class EnumWriterPageState;
 
 class EnumColumnWriter : public PrimitiveColumnWriter {
 public:
-	EnumColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema, vector<string> schema_path_p,
-	                 bool can_have_nulls);
+	EnumColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p);
 	~EnumColumnWriter() override = default;
 
 	uint32_t bit_width;

--- a/extension/parquet/include/writer/enum_column_writer.hpp
+++ b/extension/parquet/include/writer/enum_column_writer.hpp
@@ -15,7 +15,7 @@ class EnumWriterPageState;
 
 class EnumColumnWriter : public PrimitiveColumnWriter {
 public:
-	EnumColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p);
+	EnumColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema, vector<string> schema_path_p);
 	~EnumColumnWriter() override = default;
 
 	uint32_t bit_width;

--- a/extension/parquet/include/writer/list_column_writer.hpp
+++ b/extension/parquet/include/writer/list_column_writer.hpp
@@ -26,9 +26,9 @@ public:
 
 class ListColumnWriter : public ColumnWriter {
 public:
-	ListColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema, vector<string> schema_path_p,
-	                 unique_ptr<ColumnWriter> child_writer_p, bool can_have_nulls)
-	    : ColumnWriter(writer, column_schema, std::move(schema_path_p), can_have_nulls) {
+	ListColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p,
+	                 unique_ptr<ColumnWriter> child_writer_p)
+	    : ColumnWriter(writer, column_schema, std::move(schema_path_p)) {
 		child_writers.push_back(std::move(child_writer_p));
 	}
 	~ListColumnWriter() override = default;
@@ -44,6 +44,7 @@ public:
 	void BeginWrite(ColumnWriterState &state) override;
 	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override;
 	void FinalizeWrite(ColumnWriterState &state) override;
+	void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
 
 protected:
 	ColumnWriter &GetChildWriter();

--- a/extension/parquet/include/writer/list_column_writer.hpp
+++ b/extension/parquet/include/writer/list_column_writer.hpp
@@ -26,9 +26,9 @@ public:
 
 class ListColumnWriter : public ColumnWriter {
 public:
-	ListColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p,
+	ListColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema, vector<string> schema_path_p,
 	                 unique_ptr<ColumnWriter> child_writer_p)
-	    : ColumnWriter(writer, column_schema, std::move(schema_path_p)) {
+	    : ColumnWriter(writer, std::move(column_schema), std::move(schema_path_p)) {
 		child_writers.push_back(std::move(child_writer_p));
 	}
 	~ListColumnWriter() override = default;

--- a/extension/parquet/include/writer/primitive_column_writer.hpp
+++ b/extension/parquet/include/writer/primitive_column_writer.hpp
@@ -57,8 +57,7 @@ public:
 //! Base class for writing non-compound types (ex. numerics, strings)
 class PrimitiveColumnWriter : public ColumnWriter {
 public:
-	PrimitiveColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema, vector<string> schema_path,
-	                      bool can_have_nulls);
+	PrimitiveColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path);
 	~PrimitiveColumnWriter() override = default;
 
 	//! We limit the uncompressed page size to 100MB
@@ -75,6 +74,7 @@ public:
 	void BeginWrite(ColumnWriterState &state) override;
 	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override;
 	void FinalizeWrite(ColumnWriterState &state) override;
+	void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
 
 protected:
 	static void WriteLevels(Allocator &allocator, WriteStream &temp_writer, const unsafe_vector<uint16_t> &levels,

--- a/extension/parquet/include/writer/primitive_column_writer.hpp
+++ b/extension/parquet/include/writer/primitive_column_writer.hpp
@@ -57,7 +57,7 @@ public:
 //! Base class for writing non-compound types (ex. numerics, strings)
 class PrimitiveColumnWriter : public ColumnWriter {
 public:
-	PrimitiveColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path);
+	PrimitiveColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema, vector<string> schema_path);
 	~PrimitiveColumnWriter() override = default;
 
 	//! We limit the uncompressed page size to 100MB

--- a/extension/parquet/include/writer/struct_column_writer.hpp
+++ b/extension/parquet/include/writer/struct_column_writer.hpp
@@ -14,9 +14,9 @@ namespace duckdb {
 
 class StructColumnWriter : public ColumnWriter {
 public:
-	StructColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema, vector<string> schema_path_p,
-	                   vector<unique_ptr<ColumnWriter>> child_writers_p, bool can_have_nulls)
-	    : ColumnWriter(writer, column_schema, std::move(schema_path_p), can_have_nulls) {
+	StructColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p,
+	                   vector<unique_ptr<ColumnWriter>> child_writers_p)
+	    : ColumnWriter(writer, column_schema, std::move(schema_path_p)) {
 		child_writers = std::move(child_writers_p);
 	}
 	~StructColumnWriter() override = default;
@@ -32,6 +32,7 @@ public:
 	void BeginWrite(ColumnWriterState &state) override;
 	void Write(ColumnWriterState &state, Vector &vector, idx_t count) override;
 	void FinalizeWrite(ColumnWriterState &state) override;
+	void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
 };
 
 } // namespace duckdb

--- a/extension/parquet/include/writer/struct_column_writer.hpp
+++ b/extension/parquet/include/writer/struct_column_writer.hpp
@@ -14,9 +14,9 @@ namespace duckdb {
 
 class StructColumnWriter : public ColumnWriter {
 public:
-	StructColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p,
+	StructColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema, vector<string> schema_path_p,
 	                   vector<unique_ptr<ColumnWriter>> child_writers_p)
-	    : ColumnWriter(writer, column_schema, std::move(schema_path_p)) {
+	    : ColumnWriter(writer, std::move(column_schema), std::move(schema_path_p)) {
 		child_writers = std::move(child_writers_p);
 	}
 	~StructColumnWriter() override = default;

--- a/extension/parquet/include/writer/templated_column_writer.hpp
+++ b/extension/parquet/include/writer/templated_column_writer.hpp
@@ -116,10 +116,8 @@ public:
 template <class SRC, class TGT, class OP = ParquetCastOperator>
 class StandardColumnWriter : public PrimitiveColumnWriter {
 public:
-	StandardColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema,
-	                     vector<string> schema_path_p, // NOLINT
-	                     bool can_have_nulls)
-	    : PrimitiveColumnWriter(writer, column_schema, std::move(schema_path_p), can_have_nulls) {
+	StandardColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p)
+	    : PrimitiveColumnWriter(writer, column_schema, std::move(schema_path_p)) {
 	}
 	~StandardColumnWriter() override = default;
 

--- a/extension/parquet/include/writer/templated_column_writer.hpp
+++ b/extension/parquet/include/writer/templated_column_writer.hpp
@@ -116,8 +116,8 @@ public:
 template <class SRC, class TGT, class OP = ParquetCastOperator>
 class StandardColumnWriter : public PrimitiveColumnWriter {
 public:
-	StandardColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p)
-	    : PrimitiveColumnWriter(writer, column_schema, std::move(schema_path_p)) {
+	StandardColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema, vector<string> schema_path_p)
+	    : PrimitiveColumnWriter(writer, std::move(column_schema), std::move(schema_path_p)) {
 	}
 	~StandardColumnWriter() override = default;
 

--- a/extension/parquet/include/writer/variant_column_writer.hpp
+++ b/extension/parquet/include/writer/variant_column_writer.hpp
@@ -15,9 +15,9 @@ namespace duckdb {
 
 class VariantColumnWriter : public StructColumnWriter {
 public:
-	VariantColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p,
+	VariantColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema, vector<string> schema_path_p,
 	                    vector<unique_ptr<ColumnWriter>> child_writers_p)
-	    : StructColumnWriter(writer, column_schema, std::move(schema_path_p), std::move(child_writers_p)) {
+	    : StructColumnWriter(writer, std::move(column_schema), std::move(schema_path_p), std::move(child_writers_p)) {
 	}
 	~VariantColumnWriter() override = default;
 

--- a/extension/parquet/include/writer/variant_column_writer.hpp
+++ b/extension/parquet/include/writer/variant_column_writer.hpp
@@ -15,12 +15,14 @@ namespace duckdb {
 
 class VariantColumnWriter : public StructColumnWriter {
 public:
-	VariantColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema, vector<string> schema_path_p,
-	                    vector<unique_ptr<ColumnWriter>> child_writers_p, bool can_have_nulls)
-	    : StructColumnWriter(writer, column_schema, std::move(schema_path_p), std::move(child_writers_p),
-	                         can_have_nulls) {
+	VariantColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema, vector<string> schema_path_p,
+	                    vector<unique_ptr<ColumnWriter>> child_writers_p)
+	    : StructColumnWriter(writer, column_schema, std::move(schema_path_p), std::move(child_writers_p)) {
 	}
 	~VariantColumnWriter() override = default;
+
+public:
+	void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
 
 public:
 	static ScalarFunction GetTransformFunction();

--- a/extension/parquet/include/writer/variant_column_writer.hpp
+++ b/extension/parquet/include/writer/variant_column_writer.hpp
@@ -10,8 +10,58 @@
 
 #include "struct_column_writer.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/common/types/variant.hpp"
+#include "duckdb/function/scalar/variant_utils.hpp"
 
 namespace duckdb {
+
+using variant_type_map = array<idx_t, static_cast<uint8_t>(VariantLogicalType::ENUM_SIZE)>;
+
+struct ObjectAnalyzeData;
+struct ArrayAnalyzeData;
+
+struct VariantAnalyzeData {
+public:
+	VariantAnalyzeData() {
+	}
+
+public:
+	//! Map for every value what type it is
+	variant_type_map type_map = {};
+	//! Map for every decimal value what physical type it has
+	array<idx_t, 3> decimal_type_map = {};
+	unique_ptr<ObjectAnalyzeData> object_data = nullptr;
+	unique_ptr<ArrayAnalyzeData> array_data = nullptr;
+};
+
+struct ObjectAnalyzeData {
+public:
+	ObjectAnalyzeData() {
+	}
+
+public:
+	case_insensitive_map_t<VariantAnalyzeData> fields;
+};
+
+struct ArrayAnalyzeData {
+public:
+	ArrayAnalyzeData() {
+	}
+
+public:
+	VariantAnalyzeData child;
+};
+
+struct VariantAnalyzeSchemaState : public ParquetAnalyzeSchemaState {
+public:
+	VariantAnalyzeSchemaState() {
+	}
+	~VariantAnalyzeSchemaState() override {
+	}
+
+public:
+	VariantAnalyzeData analyze_data;
+};
 
 class VariantColumnWriter : public StructColumnWriter {
 public:
@@ -23,6 +73,9 @@ public:
 
 public:
 	void FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) override;
+	unique_ptr<ParquetAnalyzeSchemaState> AnalyzeSchemaInit() override;
+	void AnalyzeSchema(ParquetAnalyzeSchemaState &state, Vector &input, idx_t count) override;
+	void AnalyzeSchemaFinalize(const ParquetAnalyzeSchemaState &state) override;
 
 public:
 	static ScalarFunction GetTransformFunction();

--- a/extension/parquet/include/writer/variant_column_writer.hpp
+++ b/extension/parquet/include/writer/variant_column_writer.hpp
@@ -100,6 +100,10 @@ public:
 public:
 	static ScalarFunction GetTransformFunction();
 	static LogicalType TransformTypedValueRecursive(const LogicalType &type);
+
+private:
+	//! Whether the schema of the variant has been analyzed already
+	bool is_analyzed = false;
 };
 
 } // namespace duckdb

--- a/extension/parquet/parquet_column_schema.cpp
+++ b/extension/parquet/parquet_column_schema.cpp
@@ -1,0 +1,112 @@
+#include "parquet_column_schema.hpp"
+#include "parquet_reader.hpp"
+
+namespace duckdb {
+
+void ParquetColumnSchema::SetSchemaIndex(idx_t schema_idx) {
+	D_ASSERT(!schema_index.IsValid());
+	schema_index = schema_idx;
+}
+
+//! Writer constructors
+
+ParquetColumnSchema ParquetColumnSchema::FromLogicalType(const string &name, const LogicalType &type, idx_t max_define,
+                                                         idx_t max_repeat, idx_t column_index,
+                                                         duckdb_parquet::FieldRepetitionType::type repetition_type,
+                                                         ParquetColumnSchemaType schema_type) {
+	ParquetColumnSchema res;
+	res.name = name;
+	res.max_define = max_define;
+	res.max_repeat = max_repeat;
+	res.column_index = column_index;
+	res.repetition_type = repetition_type;
+	res.schema_type = schema_type;
+	res.type = type;
+	return res;
+}
+
+//! Reader constructors
+
+ParquetColumnSchema ParquetColumnSchema::FromSchemaElement(const duckdb_parquet::SchemaElement &element,
+                                                           idx_t max_define, idx_t max_repeat, idx_t schema_index,
+                                                           idx_t column_index, ParquetColumnSchemaType schema_type,
+                                                           const ParquetOptions &options) {
+	ParquetColumnSchema res;
+	res.name = element.name;
+	res.max_define = max_define;
+	res.max_repeat = max_repeat;
+	res.schema_index = schema_index;
+	res.column_index = column_index;
+	res.schema_type = schema_type;
+	res.type = ParquetReader::DeriveLogicalType(element, options, res);
+	return res;
+}
+
+ParquetColumnSchema ParquetColumnSchema::FromParentSchema(ParquetColumnSchema parent, LogicalType result_type,
+                                                          ParquetColumnSchemaType schema_type) {
+	ParquetColumnSchema res;
+	res.name = parent.name;
+	res.max_define = parent.max_define;
+	res.max_repeat = parent.max_repeat;
+	D_ASSERT(parent.schema_index.IsValid());
+	res.schema_index = parent.schema_index;
+	res.column_index = parent.column_index;
+	res.schema_type = schema_type;
+	res.type = result_type;
+	res.children.push_back(std::move(parent));
+	return res;
+}
+
+ParquetColumnSchema ParquetColumnSchema::FromChildSchemas(const string &name, const LogicalType &type, idx_t max_define,
+                                                          idx_t max_repeat, idx_t schema_index, idx_t column_index,
+                                                          vector<ParquetColumnSchema> &&children,
+                                                          ParquetColumnSchemaType schema_type) {
+	ParquetColumnSchema res;
+	res.name = name;
+	res.max_define = max_define;
+	res.max_repeat = max_repeat;
+	res.schema_index = schema_index;
+	res.column_index = column_index;
+	res.schema_type = schema_type;
+	res.type = type;
+	res.children = std::move(children);
+	return res;
+}
+
+ParquetColumnSchema ParquetColumnSchema::FileRowNumber() {
+	ParquetColumnSchema res;
+	res.name = "file_row_number";
+	res.max_define = 0;
+	res.max_repeat = 0;
+	res.schema_index = 0;
+	res.column_index = 0;
+	res.schema_type = ParquetColumnSchemaType::FILE_ROW_NUMBER;
+	res.type = LogicalType::BIGINT, res.repetition_type = duckdb_parquet::FieldRepetitionType::type::OPTIONAL;
+	return res;
+}
+
+unique_ptr<BaseStatistics> ParquetColumnSchema::Stats(const FileMetaData &file_meta_data,
+                                                      const ParquetOptions &parquet_options, idx_t row_group_idx_p,
+                                                      const vector<ColumnChunk> &columns) const {
+	if (schema_type == ParquetColumnSchemaType::EXPRESSION) {
+		return nullptr;
+	}
+	if (schema_type == ParquetColumnSchemaType::FILE_ROW_NUMBER) {
+		auto stats = NumericStats::CreateUnknown(type);
+		auto &row_groups = file_meta_data.row_groups;
+		D_ASSERT(row_group_idx_p < row_groups.size());
+		idx_t row_group_offset_min = 0;
+		for (idx_t i = 0; i < row_group_idx_p; i++) {
+			row_group_offset_min += row_groups[i].num_rows;
+		}
+
+		NumericStats::SetMin(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_offset_min)));
+		NumericStats::SetMax(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_offset_min +
+		                                                                     row_groups[row_group_idx_p].num_rows)));
+		stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
+		return stats.ToUnique();
+	}
+	return ParquetStatisticsUtils::TransformColumnStatistics(*this, columns, parquet_options.can_have_nan);
+}
+
+} // namespace duckdb

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -807,24 +807,25 @@ static vector<unique_ptr<Expression>> ParquetWriteSelect(CopyToSelectInput &inpu
 			cast_expr->SetAlias(name);
 			result.push_back(std::move(cast_expr));
 			any_change = true;
-		} else if (input.copy_to_type == CopyToType::COPY_TO_FILE && type.id() == LogicalTypeId::VARIANT) {
-			vector<unique_ptr<Expression>> arguments;
-			arguments.push_back(std::move(expr));
-
-			auto shredded_type_str = GetShredding(input.options, name);
-			if (!shredded_type_str.empty()) {
-				arguments.push_back(make_uniq<BoundConstantExpression>(Value(shredded_type_str)));
-			}
-
-			auto transform_func = VariantColumnWriter::GetTransformFunction();
-			transform_func.bind(context, transform_func, arguments);
-
-			auto func_expr = make_uniq<BoundFunctionExpression>(transform_func.return_type, transform_func,
-			                                                    std::move(arguments), nullptr, false);
-			func_expr->SetAlias(name);
-			result.push_back(std::move(func_expr));
-			any_change = true;
 		}
+		// else if (input.copy_to_type == CopyToType::COPY_TO_FILE && type.id() == LogicalTypeId::VARIANT) {
+		//	vector<unique_ptr<Expression>> arguments;
+		//	arguments.push_back(std::move(expr));
+
+		//	auto shredded_type_str = GetShredding(input.options, name);
+		//	if (!shredded_type_str.empty()) {
+		//		arguments.push_back(make_uniq<BoundConstantExpression>(Value(shredded_type_str)));
+		//	}
+
+		//	auto transform_func = VariantColumnWriter::GetTransformFunction();
+		//	transform_func.bind(context, transform_func, arguments);
+
+		//	auto func_expr = make_uniq<BoundFunctionExpression>(transform_func.return_type, transform_func,
+		//	                                                    std::move(arguments), nullptr, false);
+		//	func_expr->SetAlias(name);
+		//	result.push_back(std::move(func_expr));
+		//	any_change = true;
+		//}
 		// If this is an EXPORT DATABASE statement, we dont want to write "lossy" types, instead cast them to VARCHAR
 		else if (input.copy_to_type == CopyToType::EXPORT_DATABASE && TypeVisitor::Contains(type, IsTypeLossy)) {
 			// Replace all lossy types with VARCHAR

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -96,34 +96,22 @@ struct ParquetWriteBindData : public TableFunctionData {
 	ParquetVersion parquet_version = ParquetVersion::V1;
 };
 
-struct ParquetWriteGlobalState : public GlobalFunctionData {
-	unique_ptr<ParquetWriter> writer;
-	optional_ptr<const PhysicalOperator> op;
-
-	void LogFlushingRowGroup(const ColumnDataCollection &buffer, const string &reason) {
-		if (!op) {
-			return;
-		}
-		DUCKDB_LOG(writer->GetContext(), PhysicalOperatorLogType, *op, "ParquetWriter", "FlushRowGroup",
-		           {{"file", writer->GetFileName()},
-		            {"rows", to_string(buffer.Count())},
-		            {"size", to_string(buffer.SizeInBytes())},
-		            {"reason", reason}});
+void ParquetWriteGlobalState::LogFlushingRowGroup(const ColumnDataCollection &buffer, const string &reason) {
+	if (!op) {
+		return;
 	}
+	DUCKDB_LOG(writer->GetContext(), PhysicalOperatorLogType, *op, "ParquetWriter", "FlushRowGroup",
+	           {{"file", writer->GetFileName()},
+	            {"rows", to_string(buffer.Count())},
+	            {"size", to_string(buffer.SizeInBytes())},
+	            {"reason", reason}});
+}
 
-	mutex lock;
-	unique_ptr<ColumnDataCollection> combine_buffer;
-};
-
-struct ParquetWriteLocalState : public LocalFunctionData {
-	explicit ParquetWriteLocalState(ClientContext &context, const vector<LogicalType> &types) : buffer(context, types) {
-		buffer.SetPartitionIndex(0); // Makes the buffer manager less likely to spill this data
-		buffer.InitializeAppend(append_state);
-	}
-
-	ColumnDataCollection buffer;
-	ColumnDataAppendState append_state;
-};
+ParquetWriteLocalState::ParquetWriteLocalState(ClientContext &context, const vector<LogicalType> &types)
+    : buffer(context, types) {
+	buffer.SetPartitionIndex(0); // Makes the buffer manager less likely to spill this data
+	buffer.InitializeAppend(append_state);
+}
 
 static void ParquetListCopyOptions(ClientContext &context, CopyOptionsInput &input) {
 	auto &copy_options = input.options;
@@ -388,7 +376,7 @@ static void ParquetWriteSink(ExecutionContext &context, FunctionData &bind_data_
 		global_state.LogFlushingRowGroup(local_state.buffer, reason);
 		// if the chunk collection exceeds a certain size (rows/bytes) we flush it to the parquet file
 		local_state.append_state.current_chunk_state.handles.clear();
-		global_state.writer->Flush(local_state.buffer);
+		global_state.writer->Flush(local_state.buffer, local_state.transform_data);
 		local_state.buffer.InitializeAppend(local_state.append_state);
 	}
 }
@@ -403,7 +391,7 @@ static void ParquetWriteCombine(ExecutionContext &context, FunctionData &bind_da
 	    local_state.buffer.SizeInBytes() >= bind_data.row_group_size_bytes / 2) {
 		// local state buffer is more than half of the row_group_size(_bytes), just flush it
 		global_state.LogFlushingRowGroup(local_state.buffer, "Combine");
-		global_state.writer->Flush(local_state.buffer);
+		global_state.writer->Flush(local_state.buffer, local_state.transform_data);
 		return;
 	}
 
@@ -418,7 +406,7 @@ static void ParquetWriteCombine(ExecutionContext &context, FunctionData &bind_da
 			guard.unlock();
 			global_state.LogFlushingRowGroup(*owned_combine_buffer, "Combine");
 			// Lock free, of course
-			global_state.writer->Flush(*owned_combine_buffer);
+			global_state.writer->Flush(*owned_combine_buffer, global_state.transform_data);
 		}
 		return;
 	}
@@ -432,7 +420,7 @@ static void ParquetWriteFinalize(ClientContext &context, FunctionData &bind_data
 	// flush the combine buffer (if it's there)
 	if (global_state.combine_buffer) {
 		global_state.LogFlushingRowGroup(*global_state.combine_buffer, "Finalize");
-		global_state.writer->Flush(*global_state.combine_buffer);
+		global_state.writer->Flush(*global_state.combine_buffer, global_state.transform_data);
 	}
 
 	// finalize: write any additional metadata to the file here
@@ -654,7 +642,8 @@ static unique_ptr<PreparedBatchData> ParquetWritePrepareBatch(ClientContext &con
                                                               unique_ptr<ColumnDataCollection> collection) {
 	auto &global_state = gstate.Cast<ParquetWriteGlobalState>();
 	auto result = make_uniq<ParquetWriteBatchData>();
-	global_state.writer->PrepareRowGroup(*collection, result->prepared_row_group);
+	unique_ptr<ParquetWriteTransformData> transform_data;
+	global_state.writer->PrepareRowGroup(*collection, result->prepared_row_group, global_state.transform_data);
 	return std::move(result);
 }
 

--- a/extension/parquet/parquet_extension.cpp
+++ b/extension/parquet/parquet_extension.cpp
@@ -219,10 +219,7 @@ static unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFun
 			} else {
 				case_insensitive_set_t variant_names;
 				for (idx_t col_idx = 0; col_idx < names.size(); col_idx++) {
-					if (sql_types[col_idx].id() != LogicalTypeId::STRUCT) {
-						continue;
-					}
-					if (sql_types[col_idx].GetAlias() != "PARQUET_VARIANT") {
+					if (sql_types[col_idx].id() != LogicalTypeId::VARIANT) {
 						continue;
 					}
 					variant_names.emplace(names[col_idx]);

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -175,6 +175,11 @@ LoadMetadata(ClientContext &context, Allocator &allocator, CachingFileHandle &fi
 }
 
 LogicalType ParquetReader::DeriveLogicalType(const SchemaElement &s_ele, ParquetColumnSchema &schema) const {
+	return DeriveLogicalType(s_ele, parquet_options, schema);
+}
+
+LogicalType ParquetReader::DeriveLogicalType(const SchemaElement &s_ele, const ParquetOptions &parquet_options,
+                                             ParquetColumnSchema &schema) {
 	// inner node
 	if (s_ele.type == Type::FIXED_LEN_BYTE_ARRAY && !s_ele.__isset.type_length) {
 		throw IOException("FIXED_LEN_BYTE_ARRAY requires length to be set");
@@ -396,10 +401,8 @@ LogicalType ParquetReader::DeriveLogicalType(const SchemaElement &s_ele, Parquet
 ParquetColumnSchema ParquetReader::ParseColumnSchema(const SchemaElement &s_ele, idx_t max_define, idx_t max_repeat,
                                                      idx_t schema_index, idx_t column_index,
                                                      ParquetColumnSchemaType type) {
-	ParquetColumnSchema schema(max_define, max_repeat, schema_index, column_index, type);
-	schema.name = s_ele.name;
-	schema.type = DeriveLogicalType(s_ele, schema);
-	return schema;
+	return ParquetColumnSchema::FromSchemaElement(s_ele, max_define, max_repeat, schema_index, column_index, type,
+	                                              parquet_options);
 }
 
 unique_ptr<ColumnReader> ParquetReader::CreateReaderRecursive(ClientContext &context,
@@ -466,63 +469,13 @@ unique_ptr<ColumnReader> ParquetReader::CreateReader(ClientContext &context) {
 		auto column_id = entry.first;
 		auto &expression = entry.second;
 		auto child_reader = std::move(root_struct_reader.child_readers[column_id]);
-		auto expr_schema = make_uniq<ParquetColumnSchema>(child_reader->Schema(), expression->return_type,
-		                                                  ParquetColumnSchemaType::EXPRESSION);
+		auto expr_schema = make_uniq<ParquetColumnSchema>(ParquetColumnSchema::FromParentSchema(
+		    child_reader->Schema(), expression->return_type, ParquetColumnSchemaType::EXPRESSION));
 		auto expr_reader = make_uniq<ExpressionColumnReader>(context, std::move(child_reader), expression->Copy(),
 		                                                     std::move(expr_schema));
 		root_struct_reader.child_readers[column_id] = std::move(expr_reader);
 	}
 	return ret;
-}
-
-ParquetColumnSchema::ParquetColumnSchema(idx_t max_define, idx_t max_repeat, idx_t schema_index, idx_t column_index,
-                                         ParquetColumnSchemaType schema_type)
-    : ParquetColumnSchema(string(), LogicalTypeId::INVALID, max_define, max_repeat, column_index,
-                          duckdb_parquet::FieldRepetitionType::OPTIONAL, schema_type) {
-	this->schema_index = schema_index;
-}
-
-void ParquetColumnSchema::SetSchemaIndex(idx_t schema_idx) {
-	D_ASSERT(!schema_index.IsValid());
-	schema_index = schema_idx;
-}
-
-ParquetColumnSchema::ParquetColumnSchema(string name_p, LogicalType type_p, idx_t max_define, idx_t max_repeat,
-                                         idx_t column_index, duckdb_parquet::FieldRepetitionType::type repetition_type,
-                                         ParquetColumnSchemaType schema_type)
-    : schema_type(schema_type), name(std::move(name_p)), type(std::move(type_p)), max_define(max_define),
-      max_repeat(max_repeat), column_index(column_index), repetition_type(repetition_type) {
-}
-
-ParquetColumnSchema::ParquetColumnSchema(ParquetColumnSchema parent, LogicalType result_type,
-                                         ParquetColumnSchemaType schema_type)
-    : schema_type(schema_type), name(parent.name), type(std::move(result_type)), max_define(parent.max_define),
-      max_repeat(parent.max_repeat), column_index(parent.column_index) {
-	children.push_back(std::move(parent));
-}
-
-unique_ptr<BaseStatistics> ParquetColumnSchema::Stats(const FileMetaData &file_meta_data,
-                                                      const ParquetOptions &parquet_options, idx_t row_group_idx_p,
-                                                      const vector<ColumnChunk> &columns) const {
-	if (schema_type == ParquetColumnSchemaType::EXPRESSION) {
-		return nullptr;
-	}
-	if (schema_type == ParquetColumnSchemaType::FILE_ROW_NUMBER) {
-		auto stats = NumericStats::CreateUnknown(type);
-		auto &row_groups = file_meta_data.row_groups;
-		D_ASSERT(row_group_idx_p < row_groups.size());
-		idx_t row_group_offset_min = 0;
-		for (idx_t i = 0; i < row_group_idx_p; i++) {
-			row_group_offset_min += row_groups[i].num_rows;
-		}
-
-		NumericStats::SetMin(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_offset_min)));
-		NumericStats::SetMax(stats, Value::BIGINT(UnsafeNumericCast<int64_t>(row_group_offset_min +
-		                                                                     row_groups[row_group_idx_p].num_rows)));
-		stats.Set(StatsInfo::CANNOT_HAVE_NULL_VALUES);
-		return stats.ToUnique();
-	}
-	return ParquetStatisticsUtils::TransformColumnStatistics(*this, columns, parquet_options.can_have_nan);
 }
 
 static bool IsVariantType(const SchemaElement &root, const vector<ParquetColumnSchema> &children) {
@@ -598,8 +551,8 @@ ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_d
 		// geoarrow types, although geometry columns, are structs and have children and are handled below.
 		if (metadata->geo_metadata && metadata->geo_metadata->IsGeometryColumn(s_ele.name) && s_ele.num_children == 0) {
 			auto root_schema = ParseColumnSchema(s_ele, max_define, max_repeat, this_idx, next_file_idx++);
-			return ParquetColumnSchema(std::move(root_schema), GeoParquetFileMetadata::GeometryType(),
-			                           ParquetColumnSchemaType::GEOMETRY);
+			return ParquetColumnSchema::FromParentSchema(std::move(root_schema), GeoParquetFileMetadata::GeometryType(),
+			                                             ParquetColumnSchemaType::GEOMETRY);
 		}
 	}
 
@@ -654,15 +607,12 @@ ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_d
 				throw IOException("MAP_KEY_VALUE needs to be repeated");
 			}
 			auto result_type = LogicalType::MAP(child_schemas[0].type, child_schemas[1].type);
-			ParquetColumnSchema struct_schema(s_ele.name, ListType::GetChildType(result_type), max_define - 1,
-			                                  max_repeat - 1, next_file_idx);
-			struct_schema.schema_index = this_idx;
-			struct_schema.children = std::move(child_schemas);
-
-			ParquetColumnSchema map_schema(s_ele.name, std::move(result_type), max_define, max_repeat, next_file_idx);
-			map_schema.schema_index = this_idx;
-			map_schema.children.push_back(std::move(struct_schema));
-			return map_schema;
+			vector<ParquetColumnSchema> map_children;
+			map_children.emplace_back(ParquetColumnSchema::FromChildSchemas(
+			    s_ele.name, ListType::GetChildType(result_type), max_define - 1, max_repeat - 1, this_idx,
+			    next_file_idx, std::move(child_schemas)));
+			return ParquetColumnSchema::FromChildSchemas(s_ele.name, result_type, max_define, max_repeat, this_idx,
+			                                             next_file_idx, std::move(map_children));
 		}
 		ParquetColumnSchema result;
 		if (child_schemas.size() > 1 || (!is_list && !is_map && !is_repeated)) {
@@ -677,14 +627,10 @@ ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_d
 			} else {
 				result_type = LogicalType::STRUCT(std::move(struct_types));
 			}
-			ParquetColumnSchema struct_schema(s_ele.name, std::move(result_type), max_define, max_repeat,
-			                                  next_file_idx);
-			struct_schema.schema_index = this_idx;
-			struct_schema.children = std::move(child_schemas);
-			if (is_variant) {
-				struct_schema.schema_type = ParquetColumnSchemaType::VARIANT;
-			}
-			result = std::move(struct_schema);
+			ParquetColumnSchemaType schema_type =
+			    is_variant ? ParquetColumnSchemaType::VARIANT : ParquetColumnSchemaType::COLUMN;
+			result = ParquetColumnSchema::FromChildSchemas(s_ele.name, result_type, max_define, max_repeat, this_idx,
+			                                               next_file_idx, std::move(child_schemas), schema_type);
 		} else {
 			// if we have a struct with only a single type, pull up
 			result = std::move(child_schemas[0]);
@@ -692,10 +638,9 @@ ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_d
 		}
 		if (is_repeated) {
 			auto list_type = LogicalType::LIST(result.type);
-			ParquetColumnSchema list_schema(s_ele.name, std::move(list_type), max_define, max_repeat, next_file_idx);
-			list_schema.schema_index = this_idx;
-			list_schema.children.push_back(std::move(result));
-			result = std::move(list_schema);
+			vector<ParquetColumnSchema> list_child = {std::move(result)};
+			result = ParquetColumnSchema::FromChildSchemas(s_ele.name, std::move(list_type), max_define, max_repeat,
+			                                               this_idx, next_file_idx, std::move(list_child));
 		}
 		result.parent_schema_index = this_idx;
 		return result;
@@ -708,17 +653,16 @@ ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_d
 		auto result = ParseColumnSchema(s_ele, max_define, max_repeat, this_idx, next_file_idx++);
 		if (s_ele.repetition_type == FieldRepetitionType::REPEATED) {
 			auto list_type = LogicalType::LIST(result.type);
-			ParquetColumnSchema list_schema(s_ele.name, std::move(list_type), max_define, max_repeat, next_file_idx);
-			list_schema.schema_index = this_idx;
-			list_schema.children.push_back(std::move(result));
-			return list_schema;
+			vector<ParquetColumnSchema> list_child = {std::move(result)};
+			return ParquetColumnSchema::FromChildSchemas(s_ele.name, std::move(list_type), max_define, max_repeat,
+			                                             this_idx, next_file_idx, std::move(list_child));
 		}
 
 		// Convert to geometry type if possible
 		if (s_ele.__isset.logicalType && (s_ele.logicalType.__isset.GEOMETRY || s_ele.logicalType.__isset.GEOGRAPHY) &&
 		    GeoParquetFileMetadata::IsGeoParquetConversionEnabled(context)) {
-			return ParquetColumnSchema(std::move(result), GeoParquetFileMetadata::GeometryType(),
-			                           ParquetColumnSchemaType::GEOMETRY);
+			return ParquetColumnSchema::FromParentSchema(std::move(result), GeoParquetFileMetadata::GeometryType(),
+			                                             ParquetColumnSchemaType::GEOMETRY);
 		}
 
 		return result;
@@ -726,9 +670,7 @@ ParquetColumnSchema ParquetReader::ParseSchemaRecursive(idx_t depth, idx_t max_d
 }
 
 static ParquetColumnSchema FileRowNumberSchema() {
-	return ParquetColumnSchema("file_row_number", LogicalType::BIGINT, 0, 0, 0,
-	                           duckdb_parquet::FieldRepetitionType::type::OPTIONAL,
-	                           ParquetColumnSchemaType::FILE_ROW_NUMBER);
+	return ParquetColumnSchema::FileRowNumber();
 }
 
 unique_ptr<ParquetColumnSchema> ParquetReader::ParseSchema(ClientContext &context) {

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -387,6 +387,7 @@ ParquetWriter::ParquetWriter(ClientContext &context, FileSystem &fs, string file
 	VerifyUniqueNames(unique_names);
 
 	// construct the column writers
+	D_ASSERT(sql_types.size() == unique_names.size());
 	for (idx_t i = 0; i < sql_types.size(); i++) {
 		vector<string> path_in_schema;
 		column_writers.push_back(ColumnWriter::CreateWriterRecursive(context, *this, path_in_schema, sql_types[i],

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -397,15 +397,14 @@ ParquetWriter::ParquetWriter(ClientContext &context, FileSystem &fs, string file
 
 	// construct the child schemas
 	for (idx_t i = 0; i < sql_types.size(); i++) {
-		auto child_schema = ColumnWriter::FillParquetSchema(file_meta_data.schema, sql_types[i], unique_names[i],
-		                                                    &field_ids, &shredding_types);
+		auto child_schema =
+		    ColumnWriter::FillParquetSchema(sql_types[i], unique_names[i], &field_ids, &shredding_types);
 		column_schemas.push_back(std::move(child_schema));
 	}
 	// now construct the writers based on the schemas
 	for (auto &child_schema : column_schemas) {
 		vector<string> path_in_schema;
-		column_writers.push_back(
-		    ColumnWriter::CreateWriterRecursive(context, *this, file_meta_data.schema, child_schema, path_in_schema));
+		column_writers.push_back(ColumnWriter::CreateWriterRecursive(context, *this, child_schema, path_in_schema));
 	}
 }
 

--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -386,16 +386,11 @@ ParquetWriter::ParquetWriter(ClientContext &context, FileSystem &fs, string file
 	auto &unique_names = column_names;
 	VerifyUniqueNames(unique_names);
 
-	// construct the child schemas
+	// construct the column writers
 	for (idx_t i = 0; i < sql_types.size(); i++) {
-		auto child_schema =
-		    ColumnWriter::FillParquetSchema(sql_types[i], unique_names[i], &field_ids, &shredding_types);
-		column_schemas.push_back(std::move(child_schema));
-	}
-	// now construct the writers based on the schemas
-	for (auto &child_schema : column_schemas) {
 		vector<string> path_in_schema;
-		column_writers.push_back(ColumnWriter::CreateWriterRecursive(context, *this, child_schema, path_in_schema));
+		column_writers.push_back(ColumnWriter::CreateWriterRecursive(context, *this, path_in_schema, sql_types[i],
+		                                                             unique_names[i], &field_ids, &shredding_types));
 	}
 }
 

--- a/extension/parquet/writer/boolean_column_writer.cpp
+++ b/extension/parquet/writer/boolean_column_writer.cpp
@@ -35,9 +35,9 @@ public:
 	uint8_t byte_pos = 0;
 };
 
-BooleanColumnWriter::BooleanColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema,
-                                         vector<string> schema_path_p, bool can_have_nulls)
-    : PrimitiveColumnWriter(writer, column_schema, std::move(schema_path_p), can_have_nulls) {
+BooleanColumnWriter::BooleanColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema,
+                                         vector<string> schema_path_p)
+    : PrimitiveColumnWriter(writer, column_schema, std::move(schema_path_p)) {
 }
 
 unique_ptr<ColumnWriterStatistics> BooleanColumnWriter::InitializeStatsState() {

--- a/extension/parquet/writer/boolean_column_writer.cpp
+++ b/extension/parquet/writer/boolean_column_writer.cpp
@@ -35,9 +35,9 @@ public:
 	uint8_t byte_pos = 0;
 };
 
-BooleanColumnWriter::BooleanColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema,
+BooleanColumnWriter::BooleanColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema,
                                          vector<string> schema_path_p)
-    : PrimitiveColumnWriter(writer, column_schema, std::move(schema_path_p)) {
+    : PrimitiveColumnWriter(writer, std::move(column_schema), std::move(schema_path_p)) {
 }
 
 unique_ptr<ColumnWriterStatistics> BooleanColumnWriter::InitializeStatsState() {

--- a/extension/parquet/writer/decimal_column_writer.cpp
+++ b/extension/parquet/writer/decimal_column_writer.cpp
@@ -66,9 +66,9 @@ public:
 	}
 };
 
-FixedDecimalColumnWriter::FixedDecimalColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema,
-                                                   vector<string> schema_path_p, bool can_have_nulls)
-    : PrimitiveColumnWriter(writer, column_schema, std::move(schema_path_p), can_have_nulls) {
+FixedDecimalColumnWriter::FixedDecimalColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema,
+                                                   vector<string> schema_path_p)
+    : PrimitiveColumnWriter(writer, column_schema, std::move(schema_path_p)) {
 }
 
 unique_ptr<ColumnWriterStatistics> FixedDecimalColumnWriter::InitializeStatsState() {

--- a/extension/parquet/writer/decimal_column_writer.cpp
+++ b/extension/parquet/writer/decimal_column_writer.cpp
@@ -66,9 +66,9 @@ public:
 	}
 };
 
-FixedDecimalColumnWriter::FixedDecimalColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema,
+FixedDecimalColumnWriter::FixedDecimalColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema,
                                                    vector<string> schema_path_p)
-    : PrimitiveColumnWriter(writer, column_schema, std::move(schema_path_p)) {
+    : PrimitiveColumnWriter(writer, std::move(column_schema), std::move(schema_path_p)) {
 }
 
 unique_ptr<ColumnWriterStatistics> FixedDecimalColumnWriter::InitializeStatsState() {

--- a/extension/parquet/writer/enum_column_writer.cpp
+++ b/extension/parquet/writer/enum_column_writer.cpp
@@ -16,9 +16,9 @@ public:
 	bool written_value;
 };
 
-EnumColumnWriter::EnumColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema,
+EnumColumnWriter::EnumColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema,
                                    vector<string> schema_path_p)
-    : PrimitiveColumnWriter(writer, column_schema, std::move(schema_path_p)) {
+    : PrimitiveColumnWriter(writer, std::move(column_schema), std::move(schema_path_p)) {
 	bit_width = RleBpDecoder::ComputeBitWidth(EnumType::GetSize(Type()));
 }
 

--- a/extension/parquet/writer/enum_column_writer.cpp
+++ b/extension/parquet/writer/enum_column_writer.cpp
@@ -16,9 +16,9 @@ public:
 	bool written_value;
 };
 
-EnumColumnWriter::EnumColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema,
-                                   vector<string> schema_path_p, bool can_have_nulls)
-    : PrimitiveColumnWriter(writer, column_schema, std::move(schema_path_p), can_have_nulls) {
+EnumColumnWriter::EnumColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema,
+                                   vector<string> schema_path_p)
+    : PrimitiveColumnWriter(writer, column_schema, std::move(schema_path_p)) {
 	bit_width = RleBpDecoder::ComputeBitWidth(EnumType::GetSize(Type()));
 }
 

--- a/extension/parquet/writer/list_column_writer.cpp
+++ b/extension/parquet/writer/list_column_writer.cpp
@@ -175,9 +175,7 @@ void ListColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &sch
 	}
 	schemas.push_back(std::move(optional_element));
 
-	//! When we're describing a MAP, we skip the dummy "list" element
 	if (type.id() != LogicalTypeId::MAP) {
-		// then a REPEATED element
 		duckdb_parquet::SchemaElement repeated_element;
 		repeated_element.repetition_type = FieldRepetitionType::REPEATED;
 		repeated_element.__isset.num_children = true;
@@ -187,10 +185,10 @@ void ListColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &sch
 		repeated_element.name = "list";
 		schemas.push_back(std::move(repeated_element));
 	} else {
+		//! When we're describing a MAP, we skip the dummy "list" element
 		//! Instead, the "key_value" struct will be marked as REPEATED
 		D_ASSERT(GetChildWriter().Schema().repetition_type == FieldRepetitionType::REPEATED);
 	}
-
 	GetChildWriter().FinalizeSchema(schemas);
 }
 

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -7,9 +7,9 @@ namespace duckdb {
 using duckdb_parquet::Encoding;
 using duckdb_parquet::PageType;
 
-PrimitiveColumnWriter::PrimitiveColumnWriter(ParquetWriter &writer, const ParquetColumnSchema &column_schema,
-                                             vector<string> schema_path, bool can_have_nulls)
-    : ColumnWriter(writer, column_schema, std::move(schema_path), can_have_nulls) {
+PrimitiveColumnWriter::PrimitiveColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema,
+                                             vector<string> schema_path)
+    : ColumnWriter(writer, column_schema, std::move(schema_path)) {
 }
 
 unique_ptr<ColumnWriterState> PrimitiveColumnWriter::InitializeWriteState(duckdb_parquet::RowGroup &row_group) {
@@ -415,6 +415,34 @@ void PrimitiveColumnWriter::WriteDictionary(PrimitiveColumnWriterState &state, u
 
 	// insert the dictionary page as the first page to write for this column
 	state.write_info.insert(state.write_info.begin(), std::move(write_info));
+}
+
+void PrimitiveColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) {
+	idx_t schema_idx = schemas.size();
+
+	auto &schema = column_schema;
+	schema.SetSchemaIndex(schema_idx);
+
+	auto &repetition_type = schema.repetition_type;
+	auto &name = schema.name;
+	auto &field_id = schema.field_id;
+	auto &type = schema.type;
+
+	duckdb_parquet::SchemaElement schema_element;
+	schema_element.type = ParquetWriter::DuckDBTypeToParquetType(type);
+	schema_element.repetition_type = repetition_type;
+	schema_element.__isset.num_children = false;
+	schema_element.__isset.type = true;
+	schema_element.__isset.repetition_type = true;
+	schema_element.name = name;
+	if (field_id.IsValid()) {
+		schema_element.__isset.field_id = true;
+		schema_element.field_id = field_id.GetIndex();
+	}
+	ParquetWriter::SetSchemaProperties(type, schema_element);
+	schemas.push_back(std::move(schema_element));
+
+	D_ASSERT(child_writers.empty());
 }
 
 } // namespace duckdb

--- a/extension/parquet/writer/primitive_column_writer.cpp
+++ b/extension/parquet/writer/primitive_column_writer.cpp
@@ -7,9 +7,9 @@ namespace duckdb {
 using duckdb_parquet::Encoding;
 using duckdb_parquet::PageType;
 
-PrimitiveColumnWriter::PrimitiveColumnWriter(ParquetWriter &writer, ParquetColumnSchema &column_schema,
+PrimitiveColumnWriter::PrimitiveColumnWriter(ParquetWriter &writer, ParquetColumnSchema &&column_schema,
                                              vector<string> schema_path)
-    : ColumnWriter(writer, column_schema, std::move(schema_path)) {
+    : ColumnWriter(writer, std::move(column_schema), std::move(schema_path)) {
 }
 
 unique_ptr<ColumnWriterState> PrimitiveColumnWriter::InitializeWriteState(duckdb_parquet::RowGroup &row_group) {

--- a/extension/parquet/writer/struct_column_writer.cpp
+++ b/extension/parquet/writer/struct_column_writer.cpp
@@ -2,6 +2,11 @@
 
 namespace duckdb {
 
+using namespace duckdb_parquet; // NOLINT
+
+using duckdb_parquet::ConvertedType;
+using duckdb_parquet::FieldRepetitionType;
+
 class StructColumnWriterState : public ColumnWriterState {
 public:
 	StructColumnWriterState(duckdb_parquet::RowGroup &row_group, idx_t col_idx)
@@ -97,6 +102,35 @@ void StructColumnWriter::FinalizeWrite(ColumnWriterState &state_p) {
 		// we add the null count of the struct to the null count of the children
 		state.child_states[child_idx]->null_count += state_p.null_count;
 		child_writers[child_idx]->FinalizeWrite(*state.child_states[child_idx]);
+	}
+}
+
+void StructColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) {
+	idx_t schema_idx = schemas.size();
+
+	auto &schema = column_schema;
+	schema.SetSchemaIndex(schema_idx);
+
+	auto &repetition_type = schema.repetition_type;
+	auto &name = schema.name;
+	auto &field_id = schema.field_id;
+
+	// set up the schema element for this struct
+	duckdb_parquet::SchemaElement schema_element;
+	schema_element.repetition_type = repetition_type;
+	schema_element.num_children = child_writers.size();
+	schema_element.__isset.num_children = true;
+	schema_element.__isset.type = false;
+	schema_element.__isset.repetition_type = true;
+	schema_element.name = name;
+	if (field_id.IsValid()) {
+		schema_element.__isset.field_id = true;
+		schema_element.field_id = field_id.GetIndex();
+	}
+	schemas.push_back(std::move(schema_element));
+
+	for (auto &child_writer : child_writers) {
+		child_writer->FinalizeSchema(schemas);
 	}
 }
 

--- a/extension/parquet/writer/variant/CMakeLists.txt
+++ b/extension/parquet/writer/variant/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library_unity(duckdb_parquet_writer_variant OBJECT convert_variant.cpp)
+add_library_unity(duckdb_parquet_writer_variant OBJECT convert_variant.cpp
+                  analyze_variant.cpp)
 
 set(PARQUET_EXTENSION_FILES
     ${PARQUET_EXTENSION_FILES} $<TARGET_OBJECTS:duckdb_parquet_writer_variant>

--- a/extension/parquet/writer/variant/analyze_variant.cpp
+++ b/extension/parquet/writer/variant/analyze_variant.cpp
@@ -1,0 +1,180 @@
+#include "writer/variant_column_writer.hpp"
+
+namespace duckdb {
+
+unique_ptr<ParquetAnalyzeSchemaState> VariantColumnWriter::AnalyzeSchemaInit() {
+	return make_uniq<VariantAnalyzeSchemaState>();
+}
+
+static void AnalyzeSchemaInternal(VariantAnalyzeData &state, UnifiedVariantVectorData &variant, idx_t row,
+                                  uint32_t values_index) {
+	if (!variant.RowIsValid(row)) {
+		state.type_map[static_cast<uint8_t>(VariantLogicalType::VARIANT_NULL)]++;
+		return;
+	}
+
+	auto type_id = variant.GetTypeId(row, values_index);
+	state.type_map[static_cast<uint8_t>(type_id)]++;
+
+	if (type_id == VariantLogicalType::OBJECT) {
+		if (!state.object_data) {
+			state.object_data = make_uniq<ObjectAnalyzeData>();
+		}
+		auto &object_data = *state.object_data;
+
+		auto nested_data = VariantUtils::DecodeNestedData(variant, row, values_index);
+		for (idx_t i = 0; i < nested_data.child_count; i++) {
+			auto child_values_index = variant.GetValuesIndex(row, i + nested_data.children_idx);
+			auto child_key_index = variant.GetKeysIndex(row, i + nested_data.children_idx);
+
+			auto &key = variant.GetKey(row, child_key_index);
+			auto &child_state = object_data.fields[key.GetString()];
+			AnalyzeSchemaInternal(child_state, variant, row, child_values_index);
+		}
+	} else if (type_id == VariantLogicalType::ARRAY) {
+		if (!state.array_data) {
+			state.array_data = make_uniq<ArrayAnalyzeData>();
+		}
+		auto &array_data = *state.array_data;
+		auto nested_data = VariantUtils::DecodeNestedData(variant, row, values_index);
+		for (idx_t i = 0; i < nested_data.child_count; i++) {
+			auto child_values_index = variant.GetValuesIndex(row, i + nested_data.children_idx);
+			auto &child_state = array_data.child;
+			AnalyzeSchemaInternal(child_state, variant, row, child_values_index);
+		}
+	} else if (type_id == VariantLogicalType::DECIMAL) {
+		auto decimal_data = VariantUtils::DecodeDecimalData(variant, row, values_index);
+		auto physical_type = decimal_data.GetPhysicalType();
+		switch (physical_type) {
+		case PhysicalType::INT32:
+			state.decimal_type_map[0]++;
+			break;
+		case PhysicalType::INT64:
+			state.decimal_type_map[1]++;
+			break;
+		case PhysicalType::INT128:
+			state.decimal_type_map[2]++;
+			break;
+		default:
+			break;
+		}
+	} else if (type_id == VariantLogicalType::BOOL_FALSE) {
+		//! Move it to bool_true to have the counts all in one place
+		state.type_map[static_cast<uint8_t>(VariantLogicalType::BOOL_TRUE)]++;
+		state.type_map[static_cast<uint8_t>(VariantLogicalType::BOOL_FALSE)]--;
+	}
+}
+
+void VariantColumnWriter::AnalyzeSchema(ParquetAnalyzeSchemaState &state_p, Vector &input, idx_t count) {
+	auto &state = state_p.Cast<VariantAnalyzeSchemaState>();
+
+	RecursiveUnifiedVectorFormat recursive_format;
+	Vector::RecursiveToUnifiedFormat(input, count, recursive_format);
+	UnifiedVariantVectorData variant(recursive_format);
+
+	for (idx_t i = 0; i < count; i++) {
+		AnalyzeSchemaInternal(state.analyze_data, variant, i, 0);
+	}
+}
+
+namespace {
+
+struct ShredAnalysisState {
+	idx_t highest_count = 0;
+	LogicalTypeId type_id;
+	PhysicalType decimal_type;
+};
+
+} // namespace
+
+template <VariantLogicalType VARIANT_TYPE, LogicalTypeId SHREDDED_TYPE>
+static void CheckPrimitive(const VariantAnalyzeData &state, ShredAnalysisState &result) {
+	auto count = state.type_map[static_cast<uint8_t>(VARIANT_TYPE)];
+	if (VARIANT_TYPE == VariantLogicalType::DECIMAL) {
+		if (!count) {
+			return;
+		}
+		auto int32_count = state.decimal_type_map[0];
+		if (int32_count > result.highest_count) {
+			result.type_id = LogicalTypeId::DECIMAL;
+			result.decimal_type = PhysicalType::INT32;
+		}
+		auto int64_count = state.decimal_type_map[1];
+		if (int64_count > result.highest_count) {
+			result.type_id = LogicalTypeId::DECIMAL;
+			result.decimal_type = PhysicalType::INT64;
+		}
+		auto int128_count = state.decimal_type_map[2];
+		if (int128_count > result.highest_count) {
+			result.type_id = LogicalTypeId::DECIMAL;
+			result.decimal_type = PhysicalType::INT128;
+		}
+	} else {
+		if (count > result.highest_count) {
+			result.highest_count = count;
+			result.type_id = SHREDDED_TYPE;
+		}
+	}
+}
+
+static LogicalType ConstructShreddedType(const VariantAnalyzeData &state) {
+	ShredAnalysisState result;
+
+	CheckPrimitive<VariantLogicalType::BOOL_TRUE, LogicalTypeId::BOOLEAN>(state, result);
+	CheckPrimitive<VariantLogicalType::INT8, LogicalTypeId::TINYINT>(state, result);
+	CheckPrimitive<VariantLogicalType::INT16, LogicalTypeId::SMALLINT>(state, result);
+	CheckPrimitive<VariantLogicalType::INT32, LogicalTypeId::INTEGER>(state, result);
+	CheckPrimitive<VariantLogicalType::INT64, LogicalTypeId::BIGINT>(state, result);
+	CheckPrimitive<VariantLogicalType::FLOAT, LogicalTypeId::FLOAT>(state, result);
+	CheckPrimitive<VariantLogicalType::DOUBLE, LogicalTypeId::DOUBLE>(state, result);
+	CheckPrimitive<VariantLogicalType::DECIMAL, LogicalTypeId::DECIMAL>(state, result);
+	CheckPrimitive<VariantLogicalType::DATE, LogicalTypeId::DATE>(state, result);
+	CheckPrimitive<VariantLogicalType::TIME_MICROS, LogicalTypeId::TIME>(state, result);
+	CheckPrimitive<VariantLogicalType::TIMESTAMP_MICROS, LogicalTypeId::TIMESTAMP>(state, result);
+	CheckPrimitive<VariantLogicalType::TIMESTAMP_NANOS, LogicalTypeId::TIMESTAMP_NS>(state, result);
+	CheckPrimitive<VariantLogicalType::TIMESTAMP_MICROS_TZ, LogicalTypeId::TIMESTAMP_TZ>(state, result);
+	CheckPrimitive<VariantLogicalType::BLOB, LogicalTypeId::BLOB>(state, result);
+	CheckPrimitive<VariantLogicalType::VARCHAR, LogicalTypeId::VARCHAR>(state, result);
+	CheckPrimitive<VariantLogicalType::UUID, LogicalTypeId::UUID>(state, result);
+
+	auto array_count = state.type_map[static_cast<uint8_t>(VariantLogicalType::ARRAY)];
+	auto object_count = state.type_map[static_cast<uint8_t>(VariantLogicalType::OBJECT)];
+	if (array_count > object_count) {
+		if (array_count > result.highest_count) {
+			auto &array_data = *state.array_data;
+			return LogicalType::LIST(ConstructShreddedType(array_data.child));
+		}
+	} else {
+		if (object_count > result.highest_count) {
+			auto &object_data = *state.object_data;
+
+			//! TODO: implement some logic to determine which fields are worth shredding, considering the overhead when
+			//! only 10% of rows make use of the field
+			child_list_t<LogicalType> field_types;
+			for (auto &field : object_data.fields) {
+				field_types.emplace_back(field.first, ConstructShreddedType(field.second));
+			}
+			return LogicalType::STRUCT(field_types);
+		}
+	}
+
+	if (result.type_id == LogicalTypeId::DECIMAL) {
+		//! TODO: what should the scale be???
+		if (result.decimal_type == PhysicalType::INT32) {
+			return LogicalType::DECIMAL(DecimalWidth<int32_t>::max, 0);
+		} else if (result.decimal_type == PhysicalType::INT64) {
+			return LogicalType::DECIMAL(DecimalWidth<int64_t>::max, 0);
+		} else if (result.decimal_type == PhysicalType::INT128) {
+			return LogicalType::DECIMAL(DecimalWidth<hugeint_t>::max, 0);
+		}
+	}
+	return result.type_id;
+}
+
+void VariantColumnWriter::AnalyzeSchemaFinalize(const ParquetAnalyzeSchemaState &state_p) {
+	auto &state = state_p.Cast<VariantAnalyzeSchemaState>();
+	auto shredded_type = ConstructShreddedType(state.analyze_data);
+	throw InternalException("Shredded type: %s", shredded_type.ToString());
+}
+
+} // namespace duckdb

--- a/extension/parquet/writer/variant/analyze_variant.cpp
+++ b/extension/parquet/writer/variant/analyze_variant.cpp
@@ -178,9 +178,17 @@ void VariantColumnWriter::AnalyzeSchemaFinalize(const ParquetAnalyzeSchemaState 
 
 	auto typed_value = TransformTypedValueRecursive(shredded_type);
 
+	auto &schema = Schema();
 	auto &context = writer.GetContext();
+	D_ASSERT(child_writers.size() == 2);
+	child_writers.pop_back();
+	//! Recreate the column writer for 'value' because this is now "optional"
+	child_writers.push_back(ColumnWriter::CreateWriterRecursive(context, writer, schema_path, LogicalType::BLOB,
+	                                                            "value", nullptr, nullptr, schema.max_repeat,
+	                                                            schema.max_define + 1, true));
 	child_writers.push_back(ColumnWriter::CreateWriterRecursive(context, writer, schema_path, typed_value,
-	                                                            "typed_value", nullptr, nullptr));
+	                                                            "typed_value", nullptr, nullptr, schema.max_repeat,
+	                                                            schema.max_define + 1, true));
 }
 
 } // namespace duckdb

--- a/extension/parquet/writer/variant/analyze_variant.cpp
+++ b/extension/parquet/writer/variant/analyze_variant.cpp
@@ -4,7 +4,11 @@
 namespace duckdb {
 
 unique_ptr<ParquetAnalyzeSchemaState> VariantColumnWriter::AnalyzeSchemaInit() {
-	return make_uniq<VariantAnalyzeSchemaState>();
+	if (child_writers.size() == 2) {
+		return make_uniq<VariantAnalyzeSchemaState>();
+	}
+	//! Variant is already shredded explicitly, no need to analyze
+	return nullptr;
 }
 
 static void AnalyzeSchemaInternal(VariantAnalyzeData &state, UnifiedVariantVectorData &variant, idx_t row,

--- a/extension/parquet/writer/variant/analyze_variant.cpp
+++ b/extension/parquet/writer/variant/analyze_variant.cpp
@@ -1,4 +1,5 @@
 #include "writer/variant_column_writer.hpp"
+#include "parquet_writer.hpp"
 
 namespace duckdb {
 
@@ -174,7 +175,12 @@ static LogicalType ConstructShreddedType(const VariantAnalyzeData &state) {
 void VariantColumnWriter::AnalyzeSchemaFinalize(const ParquetAnalyzeSchemaState &state_p) {
 	auto &state = state_p.Cast<VariantAnalyzeSchemaState>();
 	auto shredded_type = ConstructShreddedType(state.analyze_data);
-	throw InternalException("Shredded type: %s", shredded_type.ToString());
+
+	auto typed_value = TransformTypedValueRecursive(shredded_type);
+
+	auto &context = writer.GetContext();
+	child_writers.push_back(ColumnWriter::CreateWriterRecursive(context, writer, schema_path, typed_value,
+	                                                            "typed_value", nullptr, nullptr));
 }
 
 } // namespace duckdb

--- a/extension/parquet/writer/variant/convert_variant.cpp
+++ b/extension/parquet/writer/variant/convert_variant.cpp
@@ -1115,6 +1115,33 @@ static void ToParquetVariant(DataChunk &input, ExpressionState &state, Vector &r
 	WriteVariantValues(variant, result, nullptr, nullptr, nullptr, count);
 }
 
+void VariantColumnWriter::FinalizeSchema(vector<duckdb_parquet::SchemaElement> &schemas) {
+	idx_t schema_idx = schemas.size();
+
+	auto &schema = Schema();
+	schema.SetSchemaIndex(schema_idx);
+
+	auto &repetition_type = schema.repetition_type;
+	auto &name = schema.name;
+
+	// variant group
+	duckdb_parquet::SchemaElement top_element;
+	top_element.repetition_type = repetition_type;
+	top_element.num_children = child_writers.size();
+	top_element.logicalType.__isset.VARIANT = true;
+	top_element.logicalType.VARIANT.__isset.specification_version = true;
+	top_element.logicalType.VARIANT.specification_version = 1;
+	top_element.__isset.logicalType = true;
+	top_element.__isset.num_children = true;
+	top_element.__isset.repetition_type = true;
+	top_element.name = name;
+	schemas.push_back(std::move(top_element));
+
+	for (auto &child_writer : child_writers) {
+		child_writer->FinalizeSchema(schemas);
+	}
+}
+
 LogicalType VariantColumnWriter::TransformTypedValueRecursive(const LogicalType &type) {
 	switch (type.id()) {
 	case LogicalTypeId::STRUCT: {

--- a/test/parquet/test_parquet_schema.test
+++ b/test/parquet/test_parquet_schema.test
@@ -35,9 +35,23 @@ Binder Error: Parquet schema cannot be combined with union_by_name=true or hive_
 
 statement ok
 COPY (
-    SELECT 1 i1, 3 i3, 4 i4, 5 i5 UNION ALL
-    SELECT 2 i1, 3 i3, 4 i4, 5 i5
-) TO '__TEST_DIR__/partitioned' (FIELD_IDS {i1: 5, i3: 3, i4: 2, i5: 1}, PARTITION_BY i1, FORMAT parquet, WRITE_PARTITION_COLUMNS)
+	SELECT
+		1 i1,
+		3 i3,
+		4 i4,
+		5 i5
+	UNION ALL
+	SELECT
+		2 i1,
+		3 i3,
+		4 i4,
+		5 i5
+) TO '__TEST_DIR__/partitioned' (FIELD_IDS {
+	i1: 5,
+	i3: 3,
+	i4: 2,
+	i5: 1
+}, PARTITION_BY i1, FORMAT parquet, WRITE_PARTITION_COLUMNS)
 
 # auto-detection of hive partitioning is enabled by default,
 # but automatically disabled when a schema is supplied, so this should succeed

--- a/test/parquet/variant/variant_basic_writing.test
+++ b/test/parquet/variant/variant_basic_writing.test
@@ -69,11 +69,10 @@ NULL
 "this is a long string"
 "this is big enough to not be classified as a \"short string\" by parquet VARIANT"
 
-# VARIANT is only supported at the root for now
 statement error
 COPY (select [123::VARIANT]) TO '__TEST_DIR__/list_of_variant.parquet'
 ----
-Not implemented Error: Unimplemented type for Parquet "VARIANT"
+Not implemented Error: ColumnWriter of type 'VARIANT' requires a transform, but is not a root column, this isn't supported currently
 
 statement ok
 create macro data() as table (


### PR DESCRIPTION
This PR is a follow up to <insert previous PR number>

Which added the ability to provide a `SHREDDING` copy option to manually set the shredded type of a VARIANT column.
This implemented shredding and made it easy to control, but it requires manual configuration by the user.

With this PR, VARIANT columns will always be shredded based on the analysis of the first rowgroup.
(TODO: this should be queryable with `parquet_metadata` / `parquet_schema`)

This required some changes to the Parquet writing path:
- `SchemaElement` items are no longer created during bind.
- `ParquetColumnSchema` `schema_index` is now an `optional_idx`, as this index refers to the `SchemaElements` vector, which is populated later.
- `ColumnWriter` no longer takes a reference to a `ParquetColumnSchema` object, instead it now owns the schema.
- `FillParquetSchema` is removed, consolidated into `CreateWriterRecursive`
- `ParquetWriteTransformData` is introduced, this struct holds the reusable state needed to perform a pre-processing step to transform the input columns into the shape required by the ColumnWriter (relevant for VARIANT)[1].

[1] This is not as clean as I want it to be, the `ParquetWriteTransformData` can't only live in the `ParquetWriteLocalState`, there also needs to be a copy in the `ParquetWriteGlobalState` as well as in the `ParquetWritePrepareBatch` call.